### PR TITLE
feat: awaiting-permission dot in the Claude desktop app

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "displayName": "Claude Status Bar",
       "source": "./",
       "description": "Menu bar indicator for Claude Code: animated spark, elapsed timer, and open/close lifecycle.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "homepage": "https://github.com/m1ckc3s/claude-status-bar",
       "license": "MIT"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-status-bar",
   "description": "Menu bar status indicator for Claude Code: animated spark, elapsed timer, and open/close lifecycle.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "homepage": "https://github.com/m1ckc3s/claude-status-bar",
   "license": "MIT"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Claude Status Bar are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [0.2.0] - 2026-06-25
+
+### Added
+- **Awaiting-permission dot now works in the Claude desktop app**, not just the terminal CLI. Previously the yellow "awaiting permission" dot only appeared in the CLI, because the only signal we had (the `Notification` hook) never fires for permission prompts in the desktop app. The app now also listens to Claude Code's `PermissionRequest` hook, which fires the moment an approval dialog is shown in both the CLI and the desktop app, so the dot lights up the instant Claude is waiting on you to approve a tool.
+
 ## [0.1.0] - 2026-06-22
 
 ### Added
@@ -57,6 +62,7 @@ All notable changes to Claude Status Bar are documented here. This project follo
 - Signed and notarized DMG so it opens without a Gatekeeper warning.
 - Claude Code plugin marketplace manifest for the plugin install path.
 
+[0.2.0]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.2.0
 [0.1.0]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.1.0
 [0.0.5]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.0.5
 [0.0.4]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.0.4

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Signed and notarized. Open it, drag the app to Applications, launch once.
 
 - **Thinking / working** — the icon animates, with a live `1m 1s` timer.
 - **Running a tool** — a short label (`Editing`, `Reading`, `Running command`, `Using tool`, …).
-- **Awaiting permission** — a paused yellow dot (CLI only, see below).
+- **Awaiting permission** — a paused yellow dot, in both the CLI and the Desktop app.
 - **Idle / done** — rests on the Claude logo.
 
 Everything is controlled from the menu:
@@ -50,9 +50,9 @@ Everything is controlled from the menu:
 | Claude Desktop — **Chat** tab | ❌ |
 | **Cowork** | ❌ |
 
-### Permission detection is CLI-only
+### Awaiting-permission dot
 
-🟡 The "Awaiting permission" dot only fires in the CLI. The Desktop app handles permission prompts in-window and doesn't emit the notification hook, so the dot won't show there.
+🟡 As of 0.2.0 the yellow "Awaiting permission" dot fires in both the CLI and the Desktop app. It lights up the moment Claude is waiting for you to approve a tool, via Claude Code's `PermissionRequest` hook. (On auto, accept-edits, or bypass permission modes there are no prompts, so the dot never needs to show.)
 
 ## Requirements
 

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -264,10 +264,15 @@ final class StatusController: NSObject, NSMenuDelegate {
         let age = Date().timeIntervalSince1970 - ts
 
         var eff = state
-        // The Stop hook fires on normal completion, but NOT when you interrupt (Esc/Stop).
-        // In that case Claude Code appends a "[Request interrupted by user]" line to the
-        // transcript and the turn ends — detect that so we don't stay stuck on "thinking".
-        if state == "thinking" || state == "tool" {
+        // The Stop hook fires on normal completion, but NOT when you interrupt (Esc/Stop) OR
+        // deny a permission prompt. In both cases Claude Code appends a "[Request interrupted
+        // by user ...]" line to the transcript and the turn ends with NO further hook, so
+        // state.json freezes — on the bare icon ("thinking"/"tool") or, worse, stuck on the
+        // amber "awaiting permission" dot. Deny fires no hook at all (verified via the hook
+        // monitor, see CLAUDE.md), so the transcript is the only signal; recover off it.
+        // Safe for a still-pending prompt: until you decide, the transcript's last line is the
+        // assistant tool-use message, not the interrupt marker, so the dot holds.
+        if state == "thinking" || state == "tool" || state == "permission" {
             if age > 900 { eff = "idle"; label = "" } // absolute safety net
             else if let tr = current["transcript"] as? String,
                     let last = lastLine(ofFileAt: tr),

--- a/build.sh
+++ b/build.sh
@@ -23,8 +23,8 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
   <key>CFBundleDisplayName</key><string>Claude Status Bar</string>
   <key>CFBundleIdentifier</key><string>com.local.claudestatusbar</string>
   <key>CFBundleExecutable</key><string>ClaudeStatusBar</string>
-  <key>CFBundleVersion</key><string>0.1.0</string>
-  <key>CFBundleShortVersionString</key><string>0.1.0</string>
+  <key>CFBundleVersion</key><string>0.2.0</string>
+  <key>CFBundleShortVersionString</key><string>0.2.0</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>LSMinimumSystemVersion</key><string>12.0</string>
   <key>LSUIElement</key><true/>

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -18,6 +18,9 @@
     "Notification": [
       { "hooks": [{ "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/update.js\" notify" }] }
     ],
+    "PermissionRequest": [
+      { "matcher": "*", "hooks": [{ "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/update.js\" permreq" }] }
+    ],
     "Stop": [
       { "hooks": [{ "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/update.js\" stop" }] }
     ]

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -60,6 +60,7 @@ addUnmatched("UserPromptSubmit", cmd("prompt"));
 addMatched("PreToolUse", cmd("pre"));
 addMatched("PostToolUse", cmd("post"));
 addUnmatched("Notification", cmd("notify"));
+addMatched("PermissionRequest", cmd("permreq"));
 addUnmatched("Stop", cmd("stop"));
 // Lifecycle hooks (launch the app on open; the app quits itself when no longer needed)
 addUnmatched("SessionStart", life("start"));

--- a/hooks/update.js
+++ b/hooks/update.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Invoked by Claude Code hooks. Reads the hook JSON payload on stdin, maps the
 // event to a status, and atomically writes ~/.claude/statusbar/state.json.
-// Usage: node update.js <prompt|pre|post|notify|stop>
+// Usage: node update.js <prompt|pre|post|notify|permreq|stop>
 
 const fs = require("fs");
 const os = require("os");
@@ -78,6 +78,12 @@ process.stdin.on("end", () => {
       startedAt = 0;
       break;
     }
+    case "permreq":
+      // PermissionRequest fires the instant the approval dialog is shown, in BOTH the
+      // CLI and the Desktop app (unlike Notification, which is CLI-only). Fires ~30ms
+      // after `pre` so it correctly overrides the running state with the dot. On approve,
+      // `post` clears it; on deny nothing fires, so the next prompt/tool/stop clears it.
+      state = "permission"; label = "Awaiting permission"; startedAt = 0; break;
     case "stop":
       state = "done"; label = "Done"; startedAt = 0; break;
     default:


### PR DESCRIPTION
The yellow "awaiting permission" dot now fires in the Claude desktop app, not just the CLI.

## What changed
- Listen to Claude Code's `PermissionRequest` hook, which fires the instant an approval dialog is shown in both the CLI and the desktop app, and only when approval is actually needed. `update.js` maps it to the `permission` state; `install.js` and `hooks/hooks.json` register it. The CLI `Notification` path is unchanged.
- Recover from a denied prompt app-side. A deny fires no hook at all, so `evaluate()` reverts the permission state to idle when the transcript shows the "interrupted by user" marker, reusing the same recovery the Esc-interrupt path already had. A still-pending prompt keeps the dot.
- Bump to 0.2.0, update CHANGELOG, README, and the plugin/DMG hook manifests.