### PR TITLE
fix: recover stuck status on force-quit, drop spurious waiting state (0.2.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "displayName": "Claude Status Bar",
       "source": "./",
       "description": "Menu bar indicator for Claude Code: animated spark, elapsed timer, and open/close lifecycle.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "homepage": "https://github.com/m1ckc3s/claude-status-bar",
       "license": "MIT"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-status-bar",
   "description": "Menu bar status indicator for Claude Code: animated spark, elapsed timer, and open/close lifecycle.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/m1ckc3s/claude-status-bar",
   "license": "MIT"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to Claude Status Bar are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [0.2.1] - 2026-06-25
+
+### Fixed
+- Edge case where closing the app (or the Claude desktop app) mid-animation left the menu bar stuck. On reopen it would still show the old "thinking" state with the timer climbing, because a force-quit fires no Stop hook. The status now resets to the idle resting icon when the owning session ends or resumes.
+- The menu bar no longer parks on "Waiting for you" after a turn. Claude Code's CLI sends an idle notification ("Claude is waiting for your input") when a session sits idle, and the app was turning that into a persistent label. Now only permission notifications affect the icon, so it simply rests when idle.
+
 ## [0.2.0] - 2026-06-25
 
 ### Added
@@ -62,6 +68,7 @@ All notable changes to Claude Status Bar are documented here. This project follo
 - Signed and notarized DMG so it opens without a Gatekeeper warning.
 - Claude Code plugin marketplace manifest for the plugin install path.
 
+[0.2.1]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.2.1
 [0.2.0]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.2.0
 [0.1.0]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.1.0
 [0.0.5]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.0.5

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Signed and notarized. Open it, drag the app to Applications, launch once.
 <img width="1016" height="566" alt="Claude Status Bar demo" src="https://github.com/user-attachments/assets/55a7b294-e893-4f73-b16b-b8beef784400" />
 <img width="656" height="883" alt="Screenshot 2026-06-25 at 5 27 42 AM" src="https://github.com/user-attachments/assets/7a164fda-ea23-434f-a13a-18ad7bcb1b25" />
 
+> [!IMPORTANT]
+> **Multi-session support.** This is built for one active Claude Code session at a time. If you
+> run multiple sessions at once (several terminals, or a terminal plus the desktop app), the menu
+> bar follows the most recently active one. Here is the why, and how you can add it yourself:
+> **[read the story →](https://github.com/m1ckc3s/claude-status-bar/issues/8)**
+
 ---
 
 ## What it shows

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -264,14 +264,10 @@ final class StatusController: NSObject, NSMenuDelegate {
         let age = Date().timeIntervalSince1970 - ts
 
         var eff = state
-        // The Stop hook fires on normal completion, but NOT when you interrupt (Esc/Stop) OR
-        // deny a permission prompt. In both cases Claude Code appends a "[Request interrupted
-        // by user ...]" line to the transcript and the turn ends with NO further hook, so
-        // state.json freezes — on the bare icon ("thinking"/"tool") or, worse, stuck on the
-        // amber "awaiting permission" dot. Deny fires no hook at all (verified via the hook
-        // monitor, see CLAUDE.md), so the transcript is the only signal; recover off it.
-        // Safe for a still-pending prompt: until you decide, the transcript's last line is the
-        // assistant tool-use message, not the interrupt marker, so the dot holds.
+        // Stop fires on normal completion but NOT on an Esc interrupt or a denied permission
+        // prompt: Claude Code writes "[Request interrupted by user]" to the transcript and ends
+        // with no hook, freezing state.json. Recover off that marker. (Force-quit writes no
+        // marker; lifecycle.js handles that case.) Full rationale in CLAUDE.md.
         if state == "thinking" || state == "tool" || state == "permission" {
             if age > 900 { eff = "idle"; label = "" } // absolute safety net
             else if let tr = current["transcript"] as? String,

--- a/build.sh
+++ b/build.sh
@@ -23,8 +23,8 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
   <key>CFBundleDisplayName</key><string>Claude Status Bar</string>
   <key>CFBundleIdentifier</key><string>com.local.claudestatusbar</string>
   <key>CFBundleExecutable</key><string>ClaudeStatusBar</string>
-  <key>CFBundleVersion</key><string>0.2.0</string>
-  <key>CFBundleShortVersionString</key><string>0.2.0</string>
+  <key>CFBundleVersion</key><string>0.2.1</string>
+  <key>CFBundleShortVersionString</key><string>0.2.1</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>LSMinimumSystemVersion</key><string>12.0</string>
   <key>LSUIElement</key><true/>

--- a/hooks/lifecycle.js
+++ b/hooks/lifecycle.js
@@ -12,12 +12,28 @@ const BUNDLE_ID = "com.local.claudestatusbar";
 const EXEC = "ClaudeStatusBar";
 const dir = path.join(os.homedir(), ".claude", "statusbar");
 const sessDir = path.join(dir, "sessions.d");
+const statePath = path.join(dir, "state.json");
 const event = process.argv[2];
 
 fs.mkdirSync(sessDir, { recursive: true });
 
 const running = () => { try { cp.execSync(`pgrep -x ${EXEC}`, { stdio: "ignore" }); return true; } catch { return false; } };
 const safeId = (s) => String(s || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64) || "unknown";
+
+// Reset a frozen animation when its OWNING session ends/resumes (force-quit fires SessionEnd
+// but no Stop). The session-id gate is load-bearing: warmup-churn bursts must not clear a live
+// turn. Full rationale in CLAUDE.md.
+function clearStaleState(id) {
+  try {
+    const prev = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    if (safeId(prev.sessionId) !== id) return;
+    if (!["thinking", "tool", "permission"].includes(prev.state)) return;
+    const out = { ...prev, state: "idle", label: "", startedAt: 0, ts: Math.floor(Date.now() / 1000) };
+    const tmp = statePath + "." + process.pid + ".tmp";
+    fs.writeFileSync(tmp, JSON.stringify(out));
+    fs.renameSync(tmp, statePath);
+  } catch {}
+}
 
 let input = "", done = false;
 process.stdin.on("data", (d) => (input += d));
@@ -36,9 +52,11 @@ function run() {
     // crash) — clear them so the count starts honest.
     if (!running()) { try { for (const f of fs.readdirSync(sessDir)) fs.rmSync(path.join(sessDir, f), { force: true }); } catch {} }
     try { fs.writeFileSync(path.join(sessDir, id), ""); } catch {}
+    clearStaleState(id);
     cp.spawn("open", ["-g", "-b", BUNDLE_ID], { stdio: "ignore", detached: true }).unref();
   } else if (event === "end") {
     try { fs.rmSync(path.join(sessDir, id), { force: true }); } catch {}
+    clearStaleState(id);
   }
   process.exit(0);
 }

--- a/hooks/update.js
+++ b/hooks/update.js
@@ -67,22 +67,18 @@ process.stdin.on("end", () => {
       if (!startedAt) startedAt = ts;
       break;
     case "notify": {
+      // Only a permission prompt drives the icon here (CLI path; desktop uses permreq). Ignore
+      // every other Notification (esp. the idle_prompt "Claude is waiting for your input") so the
+      // icon rests instead of parking on a confusing "Waiting for you". See CLAUDE.md.
       const m = (p.message || "").toLowerCase();
-      if (m.includes("permission") || m.includes("approve") || m.includes("allow")) {
-        state = "permission"; label = "Awaiting permission";
-      } else if (m.includes("waiting")) {
-        state = "waiting"; label = "Waiting for you";
-      } else {
-        state = "waiting"; label = p.message || "Waiting";
-      }
-      startedAt = 0;
+      const isPerm = p.notification_type === "permission_prompt" ||
+        m.includes("permission") || m.includes("approve") || m.includes("allow");
+      if (!isPerm) return;
+      state = "permission"; label = "Awaiting permission"; startedAt = 0;
       break;
     }
     case "permreq":
-      // PermissionRequest fires the instant the approval dialog is shown, in BOTH the
-      // CLI and the Desktop app (unlike Notification, which is CLI-only). Fires ~30ms
-      // after `pre` so it correctly overrides the running state with the dot. On approve,
-      // `post` clears it; on deny nothing fires, so the next prompt/tool/stop clears it.
+      // Desktop-app permission signal; not redundant with notify (that's CLI-only). See CLAUDE.md.
       state = "permission"; label = "Awaiting permission"; startedAt = 0; break;
     case "stop":
       state = "done"; label = "Done"; startedAt = 0; break;


### PR DESCRIPTION
## Fixed
- **Force-quit freeze.** Force-quitting the desktop app mid-turn fires `SessionEnd` but no `Stop`, so `state.json` froze on `thinking` with the timer climbing and reopened stuck. `lifecycle.js` now resets `state.json` to idle when the owning session ends or resumes, gated on session id so the desktop's warmup-churn bursts never clear a live turn.
- **Spurious "Waiting for you".** Claude Code's CLI fires an `idle_prompt` `Notification` when a session sits idle, and `update.js` was turning that into a persistent label. Only permission notifications drive the icon now.

## Also
- Trim the verbose inline comments added for the permission feature; rationale moved to CLAUDE.md.
- Document the single-session limitation in the README (links #8).
- Bump to 0.2.1.