### PR TITLE
Multi-session support: prioritize sessions awaiting permission

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -278,19 +278,66 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     // MARK: state polling
 
+    let staleSessionAfter: TimeInterval = 900 // a crashed session's frozen state must not win forever
+
+    // Keep the bar narrow: over `max` characters, show the first `keep` plus an ellipsis.
+    // The full text always remains in the hover tooltip.
+    func truncated(_ s: String, max: Int = 20, keep: Int = 18) -> String {
+        s.count > max ? String(s.prefix(keep)) + "…" : s
+    }
+
+    // Higher = more important. A session awaiting YOUR permission must never be hidden behind
+    // another session that's merely thinking, regardless of which wrote last.
+    func priority(of state: String) -> Int {
+        switch state {
+        case "permission":        return 4
+        case "thinking", "tool":  return 3
+        case "waiting":           return 2
+        case "done":              return 1
+        default:                  return 0 // idle / unknown
+        }
+    }
+
+    // Read every per-session state file and pick the most important one (ties broken by recency).
+    // Each Claude Code session writes its own file under sessions.d/; see update.js.
+    func aggregateState() -> [String: Any] {
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(atPath: sessionsDir) else { return [:] }
+        let now = Date().timeIntervalSince1970
+        var best: [String: Any]?
+        var bestRank = -1
+        var bestTs = 0.0
+        for f in files where !f.hasSuffix(".tmp") {
+            let path = (sessionsDir as NSString).appendingPathComponent(f)
+            guard let data = fm.contents(atPath: path), !data.isEmpty,
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { continue }
+            var st = obj["state"] as? String ?? "idle"
+            let ts = (obj["ts"] as? NSNumber)?.doubleValue ?? 0
+            // A session that crashed mid-turn leaves a frozen file; don't let it outrank live work.
+            if ["thinking", "tool", "permission"].contains(st), now - ts > staleSessionAfter { st = "idle" }
+            let rank = priority(of: st)
+            if rank > bestRank || (rank == bestRank && ts > bestTs) {
+                best = obj; bestRank = rank; bestTs = ts
+            }
+        }
+        return best ?? [:]
+    }
+
     func tick() {
         checkLifecycle()
-        let fm = FileManager.default
-        guard let attrs = try? fm.attributesOfItem(atPath: statePath),
-              let m = attrs[.modificationDate] as? Date else {
-            evaluate(); return
-        }
-        if m != lastMTime {
-            lastMTime = m
+        let agg = aggregateState()
+        if agg.isEmpty {
+            // Fallback for sessions that predate per-session files: the legacy shared state.json.
+            let fm = FileManager.default
             if let data = fm.contents(atPath: statePath),
                let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
                 current = obj
+            } else {
+                current = [:]
             }
+        } else {
+            current = agg
         }
         evaluate()
     }
@@ -328,7 +375,12 @@ final class StatusController: NSObject, NSMenuDelegate {
         switch eff {
         case "thinking":  render(label: label.isEmpty ? "Thinking…" : label, color: iconColor, animate: true,  startedAt: started)
         case "tool":      render(label: label.isEmpty ? "Working…"  : label, color: iconColor, animate: true,  startedAt: started)
-        case "permission":render(label: "Awaiting permission", color: amber, animate: false, startedAt: 0, dot: true)
+        case "permission":
+            // Name the repo so you know WHICH session is blocked when several run at once.
+            // Truncate long names in the bar (full name stays in the hover tooltip).
+            let proj = current["project"] as? String ?? ""
+            let permLabel = proj.isEmpty ? "Awaiting permission" : "\(truncated(proj)) · Awaiting permission"
+            render(label: permLabel, color: amber, animate: false, startedAt: 0, dot: true)
         case "waiting":   render(label: label.isEmpty ? "Waiting" : label, color: iconColor, animate: false, startedAt: 0)
         default:          render(label: "", color: iconColor, animate: false, startedAt: 0) // done + idle: just the orange spark
         }
@@ -379,6 +431,14 @@ final class StatusController: NSObject, NSMenuDelegate {
         activeBase = label
         activeColor = color
         self.startedAt = startedAt
+
+        // Hover tooltip: always name the repo (and state), so you can tell sessions apart even in
+        // the active styles, where the bar shows only the animated icon to save width.
+        let proj = current["project"] as? String ?? ""
+        var desc = label
+        if !proj.isEmpty, let r = desc.range(of: "\(proj) · ") { desc.removeSubrange(r) } // de-dup the permission prefix
+        if desc.isEmpty { desc = "Idle" }
+        button.toolTip = proj.isEmpty ? desc : "\(proj) — \(desc)"
 
         if animate {
             if animTimer == nil {

--- a/hooks/update.js
+++ b/hooks/update.js
@@ -36,16 +36,21 @@ process.stdin.on("end", () => {
   // Register the session here too, so a session that predates the hook install (never
   // fired SessionStart) still gets tracked once it does anything. See CLAUDE.md gotcha.
   const sid = String(p.session_id || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64);
+  const sessDir = path.join(dir, "sessions.d");
+  const sessFile = sid ? path.join(sessDir, sid) : "";
   if (sid) {
     try {
-      const sessDir = path.join(dir, "sessions.d");
+      // Register the session (don't truncate an existing state file — only create if absent).
       fs.mkdirSync(sessDir, { recursive: true });
-      fs.writeFileSync(path.join(sessDir, sid), "");
+      if (!fs.existsSync(sessFile)) fs.writeFileSync(sessFile, "");
     } catch {}
   }
 
+  // Carry forward THIS session's own previous state (its startedAt clock), falling back to the
+  // legacy shared state.json for sessions that predate per-session files.
   let prev = {};
-  try { prev = JSON.parse(fs.readFileSync(statePath, "utf8")); } catch {}
+  try { prev = JSON.parse(fs.readFileSync(sessFile || statePath, "utf8")); } catch {}
+  if (!prev.state) { try { prev = JSON.parse(fs.readFileSync(statePath, "utf8")); } catch {} }
 
   const project = p.cwd ? path.basename(p.cwd) : prev.project || "";
   const ts = Math.floor(Date.now() / 1000);
@@ -87,10 +92,15 @@ process.stdin.on("end", () => {
   }
 
   const out = { state, label, tool: p.tool_name || "", project, sessionId: p.session_id || "", transcript: p.transcript_path || prev.transcript || "", startedAt, ts };
+  const writeAtomic = (dest) => {
+    const tmp = dest + "." + process.pid + ".tmp";
+    fs.writeFileSync(tmp, JSON.stringify(out));
+    fs.renameSync(tmp, dest);
+  };
   try {
     fs.mkdirSync(dir, { recursive: true });
-    const tmp = statePath + "." + process.pid + ".tmp";
-    fs.writeFileSync(tmp, JSON.stringify(out));
-    fs.renameSync(tmp, statePath);
+    writeAtomic(statePath); // legacy single-state file (kept for back-compat)
+    // Per-session state: the app aggregates these by priority across sessions.
+    if (sessFile) writeAtomic(sessFile);
   } catch {}
 });


### PR DESCRIPTION
## What & why

When several Claude Code sessions run at once, the bar used last-writer-wins on a single `state.json`: a session **blocked awaiting your permission** could be hidden behind another that was merely *thinking*, and a session writing "done" would rest the icon even while another was still working. This implements the multi-session approach outlined in #8.

## How

Following the rough shape from #8, with one adjustment (see below):

- **`hooks/update.js`** — each session now writes its own state file under `sessions.d/<session_id>` (these were previously empty markers used only for the live-session count), carrying that session's own `startedAt` clock. The legacy `state.json` is still written for back-compat.
- **`Sources/main.swift`** — stop reading one file; read every per-session state and show the most important one:
  `permission > thinking/tool > waiting > done > idle`, ties broken by recency, with a 15-minute staleness guard so a crashed session's frozen state can't win forever.
- **`hooks/lifecycle.js`** — no change needed: it already removes a session's file on `SessionEnd`, which now also removes it from aggregation.

### Adjustment vs. the issue

The issue suggested "label and timer follow the most recent active one." I instead surface the **highest-priority** session (permission first), then break ties by recency — so a session waiting on your approval is never hidden behind one that's just thinking. Recovery paths (Esc interrupt via the transcript marker, force-quit via `SessionEnd`, the absolute age safety net) are preserved and operate on the selected session.

I reused the existing `sessions.d/` directory rather than introducing a new `state.d/`, to keep the moving parts minimal (it was already the source of truth for the live-session count and lifecycle).

## Extras (small, opt-out friendly)

- **Repo name in the permission label** — `api · Awaiting permission`, so you know *which* session is blocked. Truncated to 18 chars + ellipsis when long.
- **Hover tooltip** — names the repo and state in every animation style, so sessions stay distinguishable even when the bar shows only the animated icon (no extra bar width).

## Testing

Built locally with `swiftc` (Command Line Tools, no Xcode). Verified the aggregation with two simulated sessions: with one *thinking* (`web`) and one *awaiting permission* (`api`), the bar shows `api · Awaiting permission` regardless of write order, confirming priority beats recency. Long repo names truncate in the bar while the tooltip keeps the full name.

Addresses #8
