### PR TITLE
Multi-session support: per-session state, priority surfacing, and CLI/desktop tags

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "displayName": "Claude Status Bar",
       "source": "./",
       "description": "Menu bar indicator for Claude Code: animated spark, elapsed timer, and open/close lifecycle.",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "homepage": "https://github.com/m1ckc3s/claude-status-bar",
       "license": "MIT"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-status-bar",
   "description": "Menu bar status indicator for Claude Code: animated spark, elapsed timer, and open/close lifecycle.",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "homepage": "https://github.com/m1ckc3s/claude-status-bar",
   "license": "MIT"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 # Private maintainer notes (kept out of the public repo)
 CLAUDE.md
 ROADMAP.md
+ACKNOWLEDGEMENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to Claude Status Bar are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [0.3.0] - 2026-06-26
+
+### Added
+- **Multi-session support.** The menu bar now tracks every running Claude Code session at once instead of one at a time. When several are active it surfaces the most important one in the bar (a session awaiting your permission outranks one that's working, which outranks idle) and lists them all in the dropdown.
+- **Session dropdown.** Each running session gets its own row showing its project, a live status icon (a spinner while working, an amber dot when it needs your approval, a caret when resting), an elapsed timer, and a CLI or APP tag for where it's running.
+- **Click a session to jump to it.** Clicking a desktop-app session brings the Claude app forward; clicking a terminal session brings its terminal app forward. Heads up: it raises the terminal app, not a specific window or tab, so if you have several terminal windows open it surfaces your most recent one, not necessarily the exact session you clicked. Precise per-tab focus is in progress: [issue #19](https://github.com/m1ckc3s/claude-status-bar/issues/19).
+- **Hide idle sessions** after a delay you choose (5, 15, or 30 minutes, 1 hour, or never), so the list stays focused on what's active.
+- **Intel Mac support.** The app now ships as a universal binary and runs natively on both Apple Silicon and Intel Macs.
+
+### Changed
+- The menu is now organized around sessions: a Sessions list at the top, with Options, animation, and color settings below.
+
 ## [0.2.2] - 2026-06-25
 
 ### Fixed
@@ -73,6 +85,7 @@ All notable changes to Claude Status Bar are documented here. This project follo
 - Signed and notarized DMG so it opens without a Gatekeeper warning.
 - Claude Code plugin marketplace manifest for the plugin install path.
 
+[0.3.0]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.3.0
 [0.2.2]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.2.2
 [0.2.1]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.2.1
 [0.2.0]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to Claude Status Bar are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [0.3.0] - 2026-06-25
+
+### Added
+- **Multi-session support.** Each Claude Code session now gets its own state file (`~/.claude/statusbar/state.d/<session_id>.json`) instead of all sessions sharing one. The menu bar aggregates across every live session: the awaiting-permission dot shows if *any* session needs approval, the icon animates while *any* session is working, and it rests only when all are idle. The dropdown lists each live session as "project — status", with each session's elapsed timer updating live while the menu is open. This also fixes two issues in the single-file model: a finished session no longer rests the icon while another is still working, and a session can no longer inherit another's timer.
+- **Highest-priority session is surfaced.** With several sessions at once, the bar shows the most important one — awaiting-permission > working > idle, ties broken by most-recent activity — so a session blocked on your approval is never hidden behind one that's merely thinking. The permission label names the blocked repo (`api · Awaiting permission`, truncated when long), and a hover tooltip plus every dropdown row name the repo and whether it's running in the **CLI** or the **desktop app** (detected via `CLAUDE_CODE_ENTRYPOINT`).
+
 ## [0.2.2] - 2026-06-25
 
 ### Fixed
@@ -73,6 +79,7 @@ All notable changes to Claude Status Bar are documented here. This project follo
 - Signed and notarized DMG so it opens without a Gatekeeper warning.
 - Claude Code plugin marketplace manifest for the plugin install path.
 
+[0.3.0]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.3.0
 [0.2.2]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.2.2
 [0.2.1]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.2.1
 [0.2.0]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to Claude Status Bar are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
-## [0.3.0] - 2026-06-25
-
-### Added
-- **Multi-session support.** Each Claude Code session now gets its own state file (`~/.claude/statusbar/state.d/<session_id>.json`) instead of all sessions sharing one. The menu bar aggregates across every live session: the awaiting-permission dot shows if *any* session needs approval, the icon animates while *any* session is working, and it rests only when all are idle. The dropdown lists each live session as "project — status", with each session's elapsed timer updating live while the menu is open. This also fixes two issues in the single-file model: a finished session no longer rests the icon while another is still working, and a session can no longer inherit another's timer.
-- **Highest-priority session is surfaced.** With several sessions at once, the bar shows the most important one — awaiting-permission > working > idle, ties broken by most-recent activity — so a session blocked on your approval is never hidden behind one that's merely thinking. The permission label names the blocked repo (`api · Awaiting permission`, truncated when long), and a hover tooltip plus every dropdown row name the repo and whether it's running in the **CLI** or the **desktop app** (detected via `CLAUDE_CODE_ENTRYPOINT`).
-
 ## [0.2.2] - 2026-06-25
 
 ### Fixed
@@ -79,7 +73,6 @@ All notable changes to Claude Status Bar are documented here. This project follo
 - Signed and notarized DMG so it opens without a Gatekeeper warning.
 - Claude Code plugin marketplace manifest for the plugin install path.
 
-[0.3.0]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.3.0
 [0.2.2]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.2.2
 [0.2.1]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.2.1
 [0.2.0]: https://github.com/m1ckc3s/claude-status-bar/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ A tiny macOS menu bar app that shows **Claude Code's live status**: an animated 
 <br>
 
 > [!IMPORTANT]
-> **Multi-session support.** This is built for one active Claude Code session at a time. If you
-> run multiple sessions at once (several terminals, or a terminal plus the desktop app), the menu
-> bar follows the most recently active one. Here is the why, and how you can add it yourself:
-> **[read the story →](https://github.com/m1ckc3s/claude-status-bar/issues/8)**
+> **Multi-session support.** When several Claude Code sessions run at once (multiple terminals, or
+> a terminal plus the desktop app), the menu bar surfaces the highest-priority one — a session
+> awaiting your permission is never hidden behind one that's merely thinking — names the repo, and
+> the dropdown lists every live session. Background:
+> **[issue #8 →](https://github.com/m1ckc3s/claude-status-bar/issues/8)**
 
 ---
 
@@ -84,7 +85,7 @@ The plugin installs the hooks but not the app itself, so drag **Claude Status Ba
 
 ## How it works
 
-The app is stateless. Claude Code hooks write the current status to `~/.claude/statusbar/state.json`; the app polls that file every 0.4s and renders the icon and label. `SessionStart` launches it; it self-quits once the Claude desktop app is closed and no Claude Code session is active (each active session is a file under `~/.claude/statusbar/sessions.d/`).
+The app is stateless. Claude Code hooks write each session's status to its own file under `~/.claude/statusbar/state.d/<session_id>.json`; the app polls that directory every 0.4s, aggregates across all live sessions, and renders one icon and label (permission dot if any session needs approval, animating if any is working, resting only when all are idle). `SessionStart` launches it; it self-quits once the Claude desktop app is closed and no Claude Code session is active (each active session is its file under `~/.claude/statusbar/state.d/`).
 
 The installer merges its hooks into `~/.claude/settings.json` (backing it up first), and the app's only network call is a once-a-day GitHub release check ([details](docs/privacy.md)).
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ A tiny macOS menu bar app that shows **Claude Code's live status**: an animated 
 > **Multi-session support.** When several Claude Code sessions run at once (multiple terminals, or
 > a terminal plus the desktop app), the menu bar surfaces the highest-priority one — a session
 > awaiting your permission is never hidden behind one that's merely thinking — names the repo, and
-> the dropdown lists every live session. Background:
-> **[issue #8 →](https://github.com/m1ckc3s/claude-status-bar/issues/8)**
+> the dropdown lists every live session. Click a session to jump to it: desktop sessions focus
+> the Claude app, terminal sessions bring their terminal app to the front (the app, not yet the
+> exact window or tab when you have several open). Precise per-tab focus is in progress:
+> **[issue #19 →](https://github.com/m1ckc3s/claude-status-bar/issues/19)**.
+> Background: **[issue #8 →](https://github.com/m1ckc3s/claude-status-bar/issues/8)**
 
 ---
 

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -2,11 +2,9 @@ import Cocoa
 
 final class StatusController: NSObject, NSMenuDelegate {
     let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-    let statePath = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/statusbar/state.json")
-    let sessionsDir = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/statusbar/sessions.d")
+    let stateDir = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/statusbar/state.d")
     let claudeDesktopBundleID = "com.anthropic.claudefordesktop"
 
-    var lastMTime: Date = .distantPast
     var pollTimer: Timer?
     var animTimer: Timer?
     var frameIdx = 0
@@ -16,7 +14,30 @@ final class StatusController: NSObject, NSMenuDelegate {
     let launchGrace: TimeInterval = 5   // settle time after launch before we may quit
     let idleQuitDelay: TimeInterval = 3 // "not needed" must persist this long before quitting
 
-    var current: [String: Any] = [:]
+    // One parsed entry per live session file (state.d/<id>.json), refreshed each tick.
+    struct Session {
+        var id: String, state: String, label: String, project: String, transcript: String
+        var entrypoint: String  // CLAUDE_CODE_ENTRYPOINT: "cli", "claude-desktop", …
+        var startedAt: Double, ts: Double
+        var eff: String = ""   // effective state, recomputed once per tick in evaluate()
+
+        init(json o: [String: Any], id: String) {
+            self.id = id
+            self.state = o["state"] as? String ?? "idle"
+            self.label = o["label"] as? String ?? ""
+            self.project = o["project"] as? String ?? ""
+            self.transcript = o["transcript"] as? String ?? ""
+            self.entrypoint = o["entrypoint"] as? String ?? ""
+            self.startedAt = (o["startedAt"] as? NSNumber)?.doubleValue ?? 0
+            self.ts = (o["ts"] as? NSNumber)?.doubleValue ?? 0
+        }
+    }
+    var sessions: [String: Session] = [:]  // id -> latest parsed per-session state
+    var fileMTimes: [String: Date] = [:]   // "<id>.json" -> last-parsed mtime (re-parse only on change)
+    var soundPrev: [String: String] = [:]  // id -> previous raw state (completion-sound edge)
+    var turnStart: [String: Double] = [:]  // id -> active turn start (1-min sound gate)
+    var menuIsOpen = false                  // refresh the dropdown's per-session timers only while open
+    var sessionMenuItems: [(item: NSMenuItem, id: String)] = []
     var activeBase = ""        // label without the elapsed clock
     var startedAt: Double = 0  // unix seconds the current turn began (0 = no clock)
     var activeColor: NSColor? = nil
@@ -37,8 +58,6 @@ final class StatusController: NSObject, NSMenuDelegate {
         s.volume = 0.7 // the clip is loud at full system volume; play it a bit softer
         return s
     }()
-    var prevEff = ""               // last effective state, for detecting turn completion
-    var lastTurnStart: Double = 0  // active turn's start time, for the 1-minute gate
     var iconColor: NSColor? { iconSystem ? nil : brand } // nil => render as an adaptive template
     let codeGlyphs = ["✻", "✽", "✶", "✳", "✢"]
     let codePeaks: [CGFloat] = [1.0, 1.0, 1.0, 1.0, 1.0]
@@ -180,6 +199,19 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     // MARK: menu
 
+    // The poll timer runs in .common mode, so it keeps firing while the menu tracks; we use that
+    // to live-update the per-session elapsed clocks. menuNeedsUpdate rebuilds the rows on each open.
+    func menuWillOpen(_ menu: NSMenu) { menuIsOpen = true }
+    func menuDidClose(_ menu: NSMenu) { menuIsOpen = false; sessionMenuItems.removeAll() }
+
+    // Re-title the open dropdown's session rows so their timers tick. Rows whose session ended
+    // freeze at their last value until the menu is reopened (the list itself is rebuilt on open).
+    func refreshOpenMenuTimers() {
+        for (item, id) in sessionMenuItems {
+            if let s = sessions[id] { item.title = sessionMenuLine(s) }
+        }
+    }
+
     func menuNeedsUpdate(_ menu: NSMenu) {
         menu.removeAllItems()
         checkForUpdate() // refreshes the update cache for next open (gated to once a day)
@@ -188,6 +220,19 @@ final class StatusController: NSObject, NSMenuDelegate {
         openItem.target = self
         menu.addItem(openItem)
         menu.addItem(.separator())
+
+        sessionMenuItems.removeAll()
+        if !sessions.isEmpty {
+            menu.addItem(header("Sessions"))
+            for s in sessions.values.sorted(by: { $0.ts > $1.ts }) {
+                let it = NSMenuItem(title: sessionMenuLine(s), action: nil, keyEquivalent: "")
+                it.isEnabled = false
+                menu.addItem(it)
+                sessionMenuItems.append((it, s.id))  // kept so tick() can live-update the timers
+            }
+            menu.addItem(.separator())
+        }
+
         menu.addItem(header("Options"))
 
         let timerItem = NSMenuItem(title: "Show timer", action: #selector(toggleTimer), keyEquivalent: "")
@@ -240,6 +285,71 @@ final class StatusController: NSObject, NSMenuDelegate {
         return it
     }
 
+    // One (disabled, informational) menu row per live session: "project (Desktop) — Status 1m2s".
+    func sessionMenuLine(_ s: Session) -> String {
+        let now = Date().timeIntervalSince1970
+        let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff  // cached by evaluate() each tick
+        var status = statusText(s, eff: eff)
+        if eff == "thinking" || eff == "tool", s.startedAt > 0 {
+            status += "  " + elapsed(max(0, Int(now - s.startedAt)))
+        }
+        return "\(sessionName(s)) — \(status)"
+    }
+
+    // The state portion of a session's display, shared by the bar label and the menu/tooltip rows.
+    func statusText(_ s: Session, eff: String) -> String {
+        switch eff {
+        case "permission":       return "Awaiting permission"
+        case "thinking", "tool": return workingLabel(s)
+        default:                 return s.state == "done" ? "Done" : "Idle"
+        }
+    }
+
+    // "project" or "project (Desktop)" — the repo plus the surface it runs in (CLI / desktop app).
+    func sessionName(_ s: Session) -> String {
+        let proj = s.project.isEmpty ? "session" : s.project
+        let tag = surfaceTag(s.entrypoint)
+        return tag.isEmpty ? proj : "\(proj) (\(tag))"
+    }
+
+    // CLAUDE_CODE_ENTRYPOINT -> a short human tag.
+    func surfaceTag(_ entrypoint: String) -> String {
+        switch entrypoint {
+        case "cli":                       return "CLI"
+        case "claude-desktop":            return "Desktop"
+        case "vscode", "vscode-insiders": return "VS Code"
+        case "":                          return ""
+        default:                          return entrypoint
+        }
+    }
+
+    // Keep the bar narrow: over `max` chars, show the first `keep` + an ellipsis (full text stays in the tooltip).
+    func truncated(_ s: String, max: Int = 20, keep: Int = 18) -> String {
+        s.count > max ? String(s.prefix(keep)) + "…" : s
+    }
+
+    // Rank a session's EFFECTIVE state for surfacing (higher = more important), so a session
+    // awaiting YOUR permission is never hidden behind one merely thinking. `eff` only ever yields
+    // permission / thinking / tool / idle (done collapses to idle; waiting is never emitted).
+    func priority(of eff: String) -> Int {
+        switch eff {
+        case "permission":       return 2
+        case "thinking", "tool": return 1
+        default:                 return 0   // idle / unknown
+        }
+    }
+
+    func workingLabel(_ s: Session) -> String {
+        if !s.label.isEmpty { return s.label }
+        return s.state == "tool" ? "Working…" : "Thinking…"
+    }
+
+    // "1m 1s" / "43s" — Claude Code's elapsed-clock style.
+    func elapsed(_ secs: Int) -> String {
+        let m = secs / 60, s = secs % 60
+        return m > 0 ? "\(m)m \(s)s" : "\(s)s"
+    }
+
     @objc func quit() { NSApp.terminate(nil) }
 
     @objc func openClaude() {
@@ -280,58 +390,101 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     func tick() {
         checkLifecycle()
-        let fm = FileManager.default
-        guard let attrs = try? fm.attributesOfItem(atPath: statePath),
-              let m = attrs[.modificationDate] as? Date else {
-            evaluate(); return
-        }
-        if m != lastMTime {
-            lastMTime = m
-            if let data = fm.contents(atPath: statePath),
-               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                current = obj
-            }
-        }
+        reloadSessions()
         evaluate()
+        if menuIsOpen { refreshOpenMenuTimers() }
     }
 
+    // The .json session files currently in state.d/ (ignores the .tmp files mid-write).
+    func stateFileNames() -> [String] {
+        ((try? FileManager.default.contentsOfDirectory(atPath: stateDir)) ?? []).filter { $0.hasSuffix(".json") }
+    }
+
+    // Refresh `sessions` from state.d/, re-parsing only files whose mtime changed (writes are
+    // atomic renames, so a content update bumps mtime and is never read torn).
+    func reloadSessions() {
+        let fm = FileManager.default
+        let files = stateFileNames()
+        let present = Set(files)
+        for key in Array(fileMTimes.keys) where !present.contains(key) {   // file gone -> drop the session
+            fileMTimes[key] = nil
+            sessions[(key as NSString).deletingPathExtension] = nil
+        }
+        for f in files {
+            let full = (stateDir as NSString).appendingPathComponent(f)
+            guard let attrs = try? fm.attributesOfItem(atPath: full),
+                  let m = attrs[.modificationDate] as? Date else { continue }
+            if fileMTimes[f] == m { continue }   // unchanged since last parse
+            fileMTimes[f] = m
+            guard let data = fm.contents(atPath: full),
+                  let o = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
+            let id = (f as NSString).deletingPathExtension
+            sessions[id] = Session(json: o, id: id)
+        }
+    }
+
+    // Each tick: refresh every session's effective state and completion-chime bookkeeping, then
+    // surface a single session in the bar.
     func evaluate() {
-        let state = current["state"] as? String ?? "idle"
-        var label = current["label"] as? String ?? ""
-        let ts = (current["ts"] as? NSNumber)?.doubleValue ?? 0
-        let started = (current["startedAt"] as? NSNumber)?.doubleValue ?? 0
-        let age = Date().timeIntervalSince1970 - ts
+        let now = Date().timeIntervalSince1970
+        var chime = false
 
-        var eff = state
-        // Stop fires on normal completion but NOT on an Esc interrupt or a denied permission
-        // prompt: Claude Code writes "[Request interrupted by user]" to the transcript and ends
-        // with no hook, freezing state.json. Recover off that marker. (Force-quit writes no
-        // marker; lifecycle.js handles that case.) Full rationale in CLAUDE.md.
-        if state == "thinking" || state == "tool" || state == "permission" {
-            if age > 900 { eff = "idle"; label = "" } // absolute safety net
-            else if let tr = current["transcript"] as? String,
-                    let last = lastLine(ofFileAt: tr),
-                    last.contains("interrupted by user") {
-                eff = "idle"; label = ""
-            }
+        for id in Array(sessions.keys) {
+            guard var s = sessions[id] else { continue }
+            s.eff = effectiveState(s, now: now)   // compute once per tick; the menu + tooltip reuse it
+            sessions[id] = s
+            if soundEdgeDone(s, now: now) { chime = true }
         }
+        for id in Array(soundPrev.keys) where sessions[id] == nil { soundPrev[id] = nil; turnStart[id] = nil }
+        if chime, playCompletionSound { completionSound?.play() }
 
-        // Chime once when a turn that ran >= 1 min transitions to "done".
-        if (eff == "thinking" || eff == "tool"), started > 0 { lastTurnStart = started }
-        if eff == "done", prevEff != "done", playCompletionSound,
-           lastTurnStart > 0, Date().timeIntervalSince1970 - lastTurnStart >= 60 {
-            completionSound?.play()
+        // Surface the single highest-priority session (permission > working > …); ties broken by
+        // recency, so within a tier the most recently active session wins.
+        let lead = sessions.values.max { a, b in
+            let pa = priority(of: a.eff), pb = priority(of: b.eff)
+            return pa == pb ? a.ts < b.ts : pa < pb
         }
-        if eff == "done" { lastTurnStart = 0 }
-        prevEff = eff
+        statusItem.button?.toolTip = lead.map(sessionMenuLine)  // names repo + surface + state on hover
 
-        switch eff {
-        case "thinking":  render(label: label.isEmpty ? "Thinking…" : label, color: iconColor, animate: true,  startedAt: started)
-        case "tool":      render(label: label.isEmpty ? "Working…"  : label, color: iconColor, animate: true,  startedAt: started)
-        case "permission":render(label: "Awaiting permission", color: amber, animate: false, startedAt: 0, dot: true)
-        case "waiting":   render(label: label.isEmpty ? "Waiting" : label, color: iconColor, animate: false, startedAt: 0)
-        default:          render(label: "", color: iconColor, animate: false, startedAt: 0) // done + idle: just the orange spark
+        guard let lead = lead else { renderResting(); return }
+        switch lead.eff {
+        case "permission":
+            // Name the blocked repo so you know WHICH session needs you (truncated; full name in tooltip).
+            let base = statusText(lead, eff: lead.eff)
+            let lbl = lead.project.isEmpty ? base : "\(truncated(lead.project)) · \(base)"
+            render(label: lbl, color: amber, animate: false, startedAt: 0, dot: true)
+        case "thinking", "tool":
+            render(label: statusText(lead, eff: lead.eff), color: iconColor, animate: true, startedAt: lead.startedAt)
+        default:
+            renderResting()   // done / idle: just the resting spark
         }
+    }
+
+    func renderResting() { render(label: "", color: iconColor, animate: false, startedAt: 0) }
+
+    // Per-session effective state with the same recovery the single-file model used: an absolute
+    // age cap, plus the transcript "interrupted by user" marker (Esc / denied permission fire no
+    // hook, freezing the file). "done" collapses to rest. Full rationale in CLAUDE.md.
+    func effectiveState(_ s: Session, now: Double) -> String {
+        if s.state == "thinking" || s.state == "tool" || s.state == "permission" {
+            if now - s.ts > 900 { return "idle" }                       // absolute safety net
+            if !s.transcript.isEmpty, let last = lastLine(ofFileAt: s.transcript),
+               last.contains("interrupted by user") { return "idle" }
+            return s.state
+        }
+        return s.state == "done" ? "idle" : s.state
+    }
+
+    // Detect a session's working->done edge for the chime (turns >= 1 min only). Updates the
+    // per-session bookkeeping every call and returns true exactly once per qualifying edge.
+    func soundEdgeDone(_ s: Session, now: Double) -> Bool {
+        let prev = soundPrev[s.id] ?? ""
+        if s.state == "thinking" || s.state == "tool", s.startedAt > 0 { turnStart[s.id] = s.startedAt }
+        var edge = false
+        if s.state == "done", prev != "done", let st = turnStart[s.id], st > 0, now - st >= 60 { edge = true }
+        if s.state == "done" { turnStart[s.id] = 0 }
+        soundPrev[s.id] = s.state
+        return edge
     }
 
     // MARK: self-quit lifecycle (rationale + warmup-churn history in CLAUDE.md)
@@ -340,9 +493,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         NSWorkspace.shared.runningApplications.contains { $0.bundleIdentifier == claudeDesktopBundleID }
     }
 
-    func sessionCount() -> Int {
-        (try? FileManager.default.contentsOfDirectory(atPath: sessionsDir).count) ?? 0
-    }
+    func sessionCount() -> Int { stateFileNames().count }
 
     // Stay while Claude desktop is open OR a session is active; otherwise quit after a
     // short debounced grace (warmup-session churn must not kill us).
@@ -405,9 +556,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         guard let button = statusItem.button else { return }
         var text = activeBase
         if showTimer, startedAt > 0 {
-            let secs = max(0, Int(Date().timeIntervalSince1970 - startedAt))
-            let m = secs / 60, s = secs % 60
-            text += "  " + (m > 0 ? "\(m)m \(s)s" : "\(s)s") // Claude Code style: "1m 1s" / "43s"
+            text += "  " + elapsed(max(0, Int(Date().timeIntervalSince1970 - startedAt)))
         }
         if text.isEmpty {
             button.imagePosition = .imageOnly

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -185,6 +185,7 @@ final class StatusController: NSObject, NSMenuDelegate {
     struct Session {
         var id: String, state: String, label: String, project: String, transcript: String
         var entrypoint: String  // CLAUDE_CODE_ENTRYPOINT: "cli", "claude-desktop", …
+        var termProgram: String // TERM_PROGRAM for CLI sessions: "Apple_Terminal", "iTerm.app", …
         var startedAt: Double, ts: Double
         var eff: String = ""   // effective state, recomputed once per tick in evaluate()
 
@@ -195,6 +196,7 @@ final class StatusController: NSObject, NSMenuDelegate {
             self.project = o["project"] as? String ?? ""
             self.transcript = o["transcript"] as? String ?? ""
             self.entrypoint = o["entrypoint"] as? String ?? ""
+            self.termProgram = o["term_program"] as? String ?? ""
             self.startedAt = (o["startedAt"] as? NSNumber)?.doubleValue ?? 0
             self.ts = (o["ts"] as? NSNumber)?.doubleValue ?? 0
         }
@@ -416,8 +418,8 @@ final class StatusController: NSObject, NSMenuDelegate {
                 let now = Date().timeIntervalSince1970
                 let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
                 let view = SessionRowView(id: s.id, width: CGFloat(uiConfig()["boxWidth"] ?? 300))
-                let sid = s.id, ep = s.entrypoint
-                view.onClick = { [weak self] in menu.cancelTracking(); self?.openSession(sid, entrypoint: ep) }
+                let sid = s.id, ep = s.entrypoint, tp = s.termProgram
+                view.onClick = { [weak self] in menu.cancelTracking(); self?.openSession(sid, entrypoint: ep, termProgram: tp) }
                 configureSessionRow(view, s, eff: eff)
                 let it = NSMenuItem()
                 it.view = view
@@ -720,15 +722,29 @@ final class StatusController: NSObject, NSMenuDelegate {
         }
     }
 
-    // Desktop session click: just focus the Claude app. Do NOT use claude://resume?session=<id>,
+    // Row click. Desktop session: focus the Claude app. Do NOT use claude://resume?session=<id>,
     // that calls importCliSession() and spawns a duplicate "ungrouped" session record
     // (local_<random>.json with cliSessionId=<id>) every click, it's an import verb, not focus.
     // The clean focus path (claude://code/<bridgeSessionId>) needs an opaque session_/cse_ bridge
     // id the app never exposes to us (not in env, not derivable from the UUID, undefined on disk).
-    // So app-to-front is the safe behavior. CLI sessions: no-op for now (terminal focus = issue #19).
-    func openSession(_ id: String, entrypoint: String) {
-        guard entrypoint == "claude-desktop" else { return }
-        openClaude()
+    // CLI session: bring its terminal APP to the front (zero permission). Targeting the exact
+    // window/tab needs a one-time Automation grant, deferred to the opt-in build (issue #19).
+    func openSession(_ id: String, entrypoint: String, termProgram: String) {
+        if entrypoint == "claude-desktop" { openClaude(); return }
+        // Map TERM_PROGRAM to a name `open -a` understands; most terminals match verbatim.
+        let app: String
+        switch termProgram {
+        case "Apple_Terminal": app = "Terminal"
+        case "iTerm.app":      app = "iTerm"
+        case "vscode":         app = "Visual Studio Code"
+        case "WarpTerminal":   app = "Warp"
+        case "":               return  // unknown surface, nothing to focus
+        default:               app = termProgram  // Ghostty, WezTerm, Tabby, Hyper, kitty, …
+        }
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        p.arguments = ["-a", app]
+        try? p.run()
     }
 
 

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -5,9 +5,10 @@ import Cocoa
 // "on" color explicitly. Layer-hosted so the knob can slide on Apple's switch spring (CASpringAnimation),
 // with the track color crossfading; CA animations run in the render server, so they play during menu tracking.
 final class ToggleView: NSView {
-    static let w: CGFloat = 28, h: CGFloat = 16
+    static let w: CGFloat = 33, h: CGFloat = 16
     private let track = CALayer()
     private let knob = CALayer()
+    private var lastToggle = Date.distantPast   // debounce: ignore a re-click within a short window
     var isOn: Bool { didSet { updateState(animated: true) } }
     var onToggle: ((Bool) -> Void)?
 
@@ -43,7 +44,7 @@ final class ToggleView: NSView {
             let spring = CASpringAnimation(keyPath: "position")
             spring.fromValue = NSValue(point: knob.presentation()?.position ?? knob.position)
             spring.toValue = NSValue(point: toPos)
-            spring.damping = 15; spring.stiffness = 180; spring.mass = 1; spring.initialVelocity = 0
+            spring.damping = 16; spring.stiffness = 260; spring.mass = 1; spring.initialVelocity = 0
             spring.duration = spring.settlingDuration
             knob.add(spring, forKey: "position")
             let col = CABasicAnimation(keyPath: "backgroundColor")
@@ -58,9 +59,107 @@ final class ToggleView: NSView {
     }
 
     override func mouseDown(with event: NSEvent) {
+        guard Date().timeIntervalSince(lastToggle) > 0.1 else { return }
+        lastToggle = Date()
         isOn.toggle()
         onToggle?(isOn)
     }
+}
+
+// A session row as a custom view so a flexible spacer can pin the timer + pill to the true trailing
+// edge (a plain menu-item title can't cross the menu's reserved shortcut/submenu-arrow column).
+// Layout: [icon] name  <spacer>  timer  [pill], with timer+pill pinned right via autoresizing.
+final class SessionRowView: NSView {
+    let id: String
+    var onClick: (() -> Void)?
+    private let iconView = NSImageView()
+    private let nameField = NSTextField(labelWithString: "")
+    private let timerField = NSTextField(labelWithString: "")
+    private let pillView = NSImageView()
+    private let pad: CGFloat = 14, iconSize: CGFloat = 16, rowH: CGFloat = 24, timerW: CGFloat = 74
+    private let highlightView = NSVisualEffectView()  // system selection material = exact native highlight
+    private var hovered = false
+    private var iconBaseTint: NSColor?       // tint when not hovered (template icons); white on hover
+    private var pillNormal: NSImage?, pillSelected: NSImage?
+
+    init(id: String, width: CGFloat) {
+        self.id = id
+        super.init(frame: NSRect(x: 0, y: 0, width: width, height: rowH))
+        autoresizingMask = [.width]
+        highlightView.material = .selection
+        highlightView.state = .active
+        highlightView.isEmphasized = true
+        highlightView.wantsLayer = true
+        highlightView.layer?.cornerRadius = 5
+        highlightView.isHidden = true
+        addSubview(highlightView)
+        iconView.frame = NSRect(x: pad, y: (rowH - iconSize) / 2, width: iconSize, height: iconSize)
+        iconView.imageScaling = .scaleProportionallyUpOrDown
+        iconView.autoresizingMask = [.maxXMargin]
+        addSubview(iconView)
+        nameField.font = .menuFont(ofSize: 0)
+        nameField.textColor = .labelColor
+        nameField.lineBreakMode = .byTruncatingTail
+        nameField.frame = NSRect(x: pad + iconSize + 8, y: (rowH - 16) / 2, width: 160, height: 16)
+        nameField.autoresizingMask = [.maxXMargin]
+        addSubview(nameField)
+        timerField.font = NSFont.monospacedSystemFont(ofSize: NSFont.menuFont(ofSize: 0).pointSize, weight: .regular)
+        timerField.textColor = .secondaryLabelColor
+        timerField.alignment = .right
+        timerField.autoresizingMask = [.minXMargin]
+        addSubview(timerField)
+        pillView.imageScaling = .scaleNone
+        pillView.autoresizingMask = [.minXMargin]
+        addSubview(pillView)
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func setIcon(_ img: NSImage?) { iconView.image = img }
+
+    func configure(icon: NSImage?, iconTint: NSColor?, name: String, timer: String?,
+                   pillNormal: NSImage?, pillSelected: NSImage?, pillInset: CGFloat, timerGap: CGFloat) {
+        let w = bounds.width
+        iconView.image = icon
+        iconBaseTint = iconTint
+        iconView.contentTintColor = hovered ? .white : iconTint
+        nameField.stringValue = name
+        self.pillNormal = pillNormal; self.pillSelected = pillSelected
+        let pill = hovered ? pillSelected : pillNormal
+        var pillLeft = w - pillInset
+        if let pill = pill {
+            pillView.isHidden = false
+            pillView.image = pill
+            pillView.frame = NSRect(x: w - pillInset - pill.size.width, y: (rowH - pill.size.height) / 2,
+                                    width: pill.size.width, height: pill.size.height)
+            pillLeft = pillView.frame.minX
+        } else { pillView.isHidden = true }
+        if let timer = timer {
+            timerField.isHidden = false
+            timerField.stringValue = timer
+            timerField.frame = NSRect(x: pillLeft - timerGap - timerW, y: (rowH - 16) / 2, width: timerW, height: 16)
+        } else { timerField.isHidden = true }
+    }
+    // Custom views don't get the menu's automatic hover highlight, so draw it ourselves.
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        trackingAreas.forEach(removeTrackingArea)
+        addTrackingArea(NSTrackingArea(rect: bounds, options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect], owner: self))
+    }
+    override func mouseEntered(with event: NSEvent) { setHover(true) }
+    override func mouseExited(with event: NSEvent) { setHover(false) }
+    private func setHover(_ h: Bool) {
+        hovered = h
+        highlightView.isHidden = !h
+        nameField.textColor = h ? .white : .labelColor
+        timerField.textColor = h ? .white : .secondaryLabelColor
+        iconView.contentTintColor = h ? .white : iconBaseTint
+        if !pillView.isHidden { pillView.image = h ? pillSelected : pillNormal }
+    }
+    override func layout() {
+        super.layout()
+        highlightView.frame = bounds.insetBy(dx: 5, dy: 0)
+    }
+    override func mouseDown(with event: NSEvent) { onClick?() }
 }
 
 final class StatusController: NSObject, NSMenuDelegate {
@@ -78,7 +177,9 @@ final class StatusController: NSObject, NSMenuDelegate {
     var notNeededSince: Date?
     let launchGrace: TimeInterval = 5   // settle time after launch before we may quit
     let idleQuitDelay: TimeInterval = 3 // "not needed" must persist this long before quitting
-    let stalePruneAge: TimeInterval = 1800 // drop a resting session from the list after 30 min quiet
+    // "Hide idle after" setting (seconds): drop a resting session from the list once it's been quiet
+    // this long. 0 = Never. Defaults to 30 min.
+    var stalePruneAge: TimeInterval { UserDefaults.standard.object(forKey: "hideIdleAfter") as? Double ?? 1800 }
 
     // One parsed entry per live session file (state.d/<id>.json), refreshed each tick.
     struct Session {
@@ -286,9 +387,9 @@ final class StatusController: NSObject, NSMenuDelegate {
         guard let img = rotatedSpinner(spinAngle) else { return }
         let now = Date().timeIntervalSince1970
         for (item, id) in sessionMenuItems {
-            guard let s = sessions[id] else { continue }
+            guard let s = sessions[id], let v = item.view as? SessionRowView else { continue }
             let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
-            if eff == "thinking" || eff == "tool" { item.image = img }
+            if eff == "thinking" || eff == "tool" { v.setIcon(img) }
         }
     }
 
@@ -298,10 +399,9 @@ final class StatusController: NSObject, NSMenuDelegate {
     func refreshOpenMenuRows() {
         let now = Date().timeIntervalSince1970
         for (item, id) in sessionMenuItems {
-            guard let s = sessions[id] else { continue }
+            guard let s = sessions[id], let v = item.view as? SessionRowView else { continue }
             let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
-            item.attributedTitle = sessionMenuAttributed(s)
-            item.image = sessionSymbol(s, eff: eff)
+            configureSessionRow(v, s, eff: eff)
         }
     }
 
@@ -313,16 +413,13 @@ final class StatusController: NSObject, NSMenuDelegate {
         if !sessions.isEmpty {
             menu.addItem(header("Sessions"))
             for s in sessions.values.sorted(by: { $0.ts > $1.ts }) {
-                let it = NSMenuItem(title: "", action: #selector(openClaude), keyEquivalent: "")
-                it.target = self
-                it.representedObject = s.id
-                it.attributedTitle = sessionMenuAttributed(s)
                 let now = Date().timeIntervalSince1970
-                it.image = sessionSymbol(s, eff: s.eff.isEmpty ? effectiveState(s, now: now) : s.eff)
-                if #available(macOS 14.0, *) {
-                    let tag = surfaceTag(s.entrypoint)
-                    if !tag.isEmpty { it.badge = NSMenuItemBadge(string: tag) }
-                }
+                let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
+                let view = SessionRowView(id: s.id, width: CGFloat(uiConfig()["boxWidth"] ?? 300))
+                view.onClick = { [weak self] in menu.cancelTracking(); self?.openClaude() }
+                configureSessionRow(view, s, eff: eff)
+                let it = NSMenuItem()
+                it.view = view
                 menu.addItem(it)
                 sessionMenuItems.append((it, s.id))  // kept so tick() can live-update the timers
             }
@@ -355,7 +452,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         animParent.submenu = animSub
         menu.addItem(animParent)
 
-        let colorParent = NSMenuItem(title: "Color", action: nil, keyEquivalent: "")
+        let colorParent = NSMenuItem(title: "Color theme", action: nil, keyEquivalent: "")
         let colorSub = NSMenu()
         for (sys, name) in [(false, "Orange"), (true, "System")] {
             let it = NSMenuItem(title: name, action: #selector(chooseColor(_:)), keyEquivalent: "")
@@ -366,6 +463,19 @@ final class StatusController: NSObject, NSMenuDelegate {
         }
         colorParent.submenu = colorSub
         menu.addItem(colorParent)
+
+        let hideParent = NSMenuItem(title: "Hide idle sessions", action: nil, keyEquivalent: "")
+        let hideSub = NSMenu()
+        let curHide = stalePruneAge
+        for (name, secs) in [("5 minutes", 300.0), ("15 minutes", 900.0), ("30 minutes", 1800.0), ("1 hour", 3600.0), ("Never", 0.0)] {
+            let it = NSMenuItem(title: name, action: #selector(chooseHideIdle(_:)), keyEquivalent: "")
+            it.target = self
+            it.representedObject = secs
+            it.state = curHide == secs ? .on : .off
+            hideSub.addItem(it)
+        }
+        hideParent.submenu = hideSub
+        menu.addItem(hideParent)
 
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Version \(currentVersion)", action: nil, keyEquivalent: ""))
@@ -392,7 +502,7 @@ final class StatusController: NSObject, NSMenuDelegate {
     // stretches the view to its full width; the switch gets a non-vibrant appearance so its "on"
     // accent fill isn't washed out by the menu's vibrancy.
     func toggleRow(title: String, isOn: Bool, onToggle: @escaping (Bool) -> Void) -> NSMenuItem {
-        let width: CGFloat = 280, height: CGFloat = 22, leftInset: CGFloat = 14, rightInset: CGFloat = 12
+        let width = CGFloat(uiConfig()["boxWidth"] ?? 300), height: CGFloat = 24, leftInset: CGFloat = 14, rightInset: CGFloat = 12
         let row = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
         row.autoresizingMask = [.width]
 
@@ -429,17 +539,30 @@ final class StatusController: NSObject, NSMenuDelegate {
     }
 
     // Same as sessionMenuLine but the trailing timer is dimmed so it reads apart from the project name.
-    func sessionMenuAttributed(_ s: Session) -> NSAttributedString {
+    // Live layout knobs read fresh from ~/.claude/statusbar/uiconfig.json each render, so numeric
+    // tweaks (timer column, pill offset, gap) take effect on the next menu open with NO rebuild.
+    func uiConfig() -> [String: Double] {
+        let p = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/statusbar/uiconfig.json")
+        guard let d = FileManager.default.contents(atPath: p),
+              let j = try? JSONSerialization.jsonObject(with: d) as? [String: Any] else { return [:] }
+        return j.compactMapValues { ($0 as? NSNumber)?.doubleValue }
+    }
+
+    func configureSessionRow(_ v: SessionRowView, _ s: Session, eff: String) {
+        let cfg = uiConfig()
         let now = Date().timeIntervalSince1970
-        let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
-        let font = NSFont.menuFont(ofSize: 0)
-        let str = NSMutableAttributedString(string: truncated(sessionName(s)),
-                                            attributes: [.font: font, .foregroundColor: NSColor.labelColor])
-        if eff == "thinking" || eff == "tool", s.startedAt > 0 {
-            str.append(NSAttributedString(string: "  " + elapsed(max(0, Int(now - s.startedAt))),
-                                          attributes: [.font: font, .foregroundColor: NSColor.secondaryLabelColor]))
-        }
-        return str
+        let nameMax = Int(cfg["nameMax"] ?? 16)
+        let working = (eff == "thinking" || eff == "tool") && s.startedAt > 0
+        let resting = !(eff == "permission" || eff == "thinking" || eff == "tool")  // the dim caret
+        let tag = surfaceTag(s.entrypoint)
+        v.configure(icon: sessionSymbol(s, eff: eff),
+                    iconTint: resting ? .tertiaryLabelColor : nil,  // caret dim; spinner uses default; amber ignores tint
+                    name: truncated(sessionName(s), max: nameMax, keep: nameMax),
+                    timer: working ? elapsed(max(0, Int(now - s.startedAt))) : nil,
+                    pillNormal: tag.isEmpty ? nil : pillImage(tag),
+                    pillSelected: tag.isEmpty ? nil : pillImage(tag, selected: true),
+                    pillInset: CGFloat(cfg["pillInset"] ?? 12),
+                    timerGap: CGFloat(cfg["timerGap"] ?? 10))
     }
 
     // The state portion of a session's display, shared by the bar label and the menu/tooltip rows.
@@ -457,13 +580,39 @@ final class StatusController: NSObject, NSMenuDelegate {
     }
 
     // CLAUDE_CODE_ENTRYPOINT -> a short all-caps badge tag.
+    // Every surface collapses to a 3-letter pill: the desktop app is APP, everything else (cli,
+    // vscode, cursor, windsurf, …) is a terminal/editor context, so CLI. Keeps pills uniform.
     func surfaceTag(_ entrypoint: String) -> String {
         switch entrypoint {
-        case "cli":                       return "CLI"
-        case "claude-desktop":            return "APP"
-        case "vscode", "vscode-insiders": return "VS CODE"
-        case "":                          return ""
-        default:                          return entrypoint.uppercased()
+        case "claude-desktop": return "APP"
+        case "":               return ""
+        default:               return "CLI"
+        }
+    }
+
+    // CLI/APP pill rendered as an image so it can sit inside the row text (right after the timer)
+    // rather than as a system badge pinned to the menu edge with a fixed, uncloseable gap.
+    func pillImage(_ text: String, selected: Bool = false) -> NSImage {
+        let t = text as NSString
+        let font = NSFont.monospacedSystemFont(ofSize: 9.5, weight: .semibold)  // mono -> 3 chars = uniform width
+        let pad: CGFloat = 7, h: CGFloat = 15
+        let cfg = uiConfig()
+        let dy = CGFloat(cfg["pillTextY"] ?? -1)  // negative nudges the text down (it reads top-heavy)
+        // Pill bg is a tunable gray per mode (black-on-light / white-on-dark at a low alpha) so light
+        // mode can be lightened independently. On a selected (blue) row it's a light translucent pill.
+        let dark = NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        let bgAlpha = CGFloat(cfg[dark ? "pillBgDark" : "pillBgLight"] ?? (dark ? 0.14 : 0.10))
+        let bg = selected ? NSColor.white.withAlphaComponent(0.22)
+                          : (dark ? NSColor.white : NSColor.black).withAlphaComponent(bgAlpha)
+        let fg = selected ? NSColor.white : NSColor.labelColor
+        let w = ceil(t.size(withAttributes: [.font: font]).width) + pad * 2
+        return NSImage(size: NSSize(width: w, height: h), flipped: false) { rect in
+            bg.setFill()
+            NSBezierPath(roundedRect: rect, xRadius: h / 2, yRadius: h / 2).fill()
+            let a: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: fg]
+            let ts = t.size(withAttributes: a)
+            t.draw(at: NSPoint(x: (rect.width - ts.width) / 2, y: (rect.height - ts.height) / 2 + dy), withAttributes: a)
+            return true
         }
     }
 
@@ -483,12 +632,14 @@ final class StatusController: NSObject, NSMenuDelegate {
         let glyph = "\u{276F}" as NSString
         let font = NSFont.systemFont(ofSize: 11, weight: .medium)
         let side = spinnerBase?.size.width ?? 15
-        return NSImage(size: NSSize(width: side, height: side), flipped: false) { _ in
-            let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.tertiaryLabelColor]
+        let img = NSImage(size: NSSize(width: side, height: side), flipped: false) { _ in
+            let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.black]
             let g = glyph.size(withAttributes: attrs)
             glyph.draw(at: NSPoint(x: (side - g.width) / 2, y: (side - g.height) / 2), withAttributes: attrs)
             return true
         }
+        img.isTemplate = true   // tint via contentTintColor: dim (tertiary) normally, white on hover
+        return img
     }()
 
     // Pre-rendered into a padded SQUARE canvas with the glyph centered, so rotation pivots on the
@@ -576,6 +727,11 @@ final class StatusController: NSObject, NSMenuDelegate {
         evaluate() // re-render the current state in the new color
     }
 
+    @objc func chooseHideIdle(_ sender: NSMenuItem) {
+        guard let secs = sender.representedObject as? Double else { return }
+        UserDefaults.standard.set(secs, forKey: "hideIdleAfter")
+    }
+
     @objc func chooseStyle(_ sender: NSMenuItem) {
         guard let raw = sender.representedObject as? String, let st = AnimStyle(rawValue: raw) else { return }
         animStyle = st
@@ -631,7 +787,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         for id in Array(sessions.keys) {
             guard var s = sessions[id] else { continue }
             s.eff = effectiveState(s, now: now)   // compute once per tick; the menu + tooltip reuse it
-            if s.eff == "idle", now - s.ts > stalePruneAge {
+            if s.eff == "idle", stalePruneAge > 0, now - s.ts > stalePruneAge {
                 // genuinely-quiet resting session: drop it. update.js rewrites the file if it acts again.
                 try? FileManager.default.removeItem(atPath: (stateDir as NSString).appendingPathComponent(id + ".json"))
                 sessions[id] = nil; fileMTimes[id + ".json"] = nil; soundPrev[id] = nil; turnStart[id] = nil

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -416,7 +416,8 @@ final class StatusController: NSObject, NSMenuDelegate {
                 let now = Date().timeIntervalSince1970
                 let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
                 let view = SessionRowView(id: s.id, width: CGFloat(uiConfig()["boxWidth"] ?? 300))
-                view.onClick = { [weak self] in menu.cancelTracking(); self?.openClaude() }
+                let sid = s.id, ep = s.entrypoint
+                view.onClick = { [weak self] in menu.cancelTracking(); self?.openSession(sid, entrypoint: ep) }
                 configureSessionRow(view, s, eff: eff)
                 let it = NSMenuItem()
                 it.view = view
@@ -717,6 +718,17 @@ final class StatusController: NSObject, NSMenuDelegate {
         if let url = ws.urlForApplication(withBundleIdentifier: "com.anthropic.claudefordesktop") {
             ws.openApplication(at: url, configuration: NSWorkspace.OpenConfiguration())
         }
+    }
+
+    // Desktop session click: just focus the Claude app. Do NOT use claude://resume?session=<id>,
+    // that calls importCliSession() and spawns a duplicate "ungrouped" session record
+    // (local_<random>.json with cliSessionId=<id>) every click, it's an import verb, not focus.
+    // The clean focus path (claude://code/<bridgeSessionId>) needs an opaque session_/cse_ bridge
+    // id the app never exposes to us (not in env, not derivable from the UUID, undefined on disk).
+    // So app-to-front is the safe behavior. CLI sessions: no-op for now (terminal focus = issue #19).
+    func openSession(_ id: String, entrypoint: String) {
+        guard entrypoint == "claude-desktop" else { return }
+        openClaude()
     }
 
 

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,5 +1,68 @@
 import Cocoa
 
+// Custom-drawn toggle. NSSwitch can't show its accent inside a menu (the menu's vibrant, non-key
+// window draws the implicit accent gray), so we render the track + knob as layers and fill the
+// "on" color explicitly. Layer-hosted so the knob can slide on Apple's switch spring (CASpringAnimation),
+// with the track color crossfading; CA animations run in the render server, so they play during menu tracking.
+final class ToggleView: NSView {
+    static let w: CGFloat = 28, h: CGFloat = 16
+    private let track = CALayer()
+    private let knob = CALayer()
+    var isOn: Bool { didSet { updateState(animated: true) } }
+    var onToggle: ((Bool) -> Void)?
+
+    init(isOn: Bool) {
+        self.isOn = isOn
+        super.init(frame: NSRect(x: 0, y: 0, width: ToggleView.w, height: ToggleView.h))
+        layer = CALayer()
+        wantsLayer = true
+        track.frame = bounds
+        track.cornerRadius = bounds.height / 2
+        layer?.addSublayer(track)
+        let kh = bounds.height - 4, kw = kh + 3   // capsule: a touch wider than tall, like modern macOS
+        knob.bounds = CGRect(x: 0, y: 0, width: kw, height: kh)
+        knob.cornerRadius = kh / 2
+        knob.backgroundColor = NSColor.white.cgColor
+        layer?.addSublayer(knob)
+        updateState(animated: false)
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+    override var intrinsicContentSize: NSSize { NSSize(width: ToggleView.w, height: ToggleView.h) }
+
+    private func knobCenter() -> CGPoint {
+        let kw = knob.bounds.width
+        return CGPoint(x: isOn ? bounds.width - kw / 2 - 2 : kw / 2 + 2, y: bounds.height / 2)
+    }
+
+    private func updateState(animated: Bool) {
+        let toColor = (isOn ? NSColor.controlAccentColor : NSColor.tertiaryLabelColor).cgColor
+        let toPos = knobCenter()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        if animated {
+            let spring = CASpringAnimation(keyPath: "position")
+            spring.fromValue = NSValue(point: knob.presentation()?.position ?? knob.position)
+            spring.toValue = NSValue(point: toPos)
+            spring.damping = 15; spring.stiffness = 180; spring.mass = 1; spring.initialVelocity = 0
+            spring.duration = spring.settlingDuration
+            knob.add(spring, forKey: "position")
+            let col = CABasicAnimation(keyPath: "backgroundColor")
+            col.fromValue = track.presentation()?.backgroundColor ?? track.backgroundColor
+            col.toValue = toColor
+            col.duration = 0.2
+            track.add(col, forKey: "backgroundColor")
+        }
+        knob.position = toPos
+        track.backgroundColor = toColor
+        CATransaction.commit()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        isOn.toggle()
+        onToggle?(isOn)
+    }
+}
+
 final class StatusController: NSObject, NSMenuDelegate {
     let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     let stateDir = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/statusbar/state.d")
@@ -7,12 +70,15 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     var pollTimer: Timer?
     var animTimer: Timer?
+    var spinTimer: Timer?      // rotates the working-state spinner while the menu is open
+    var spinAngle: CGFloat = 0
     var frameIdx = 0
 
     let launchedAt = Date()
     var notNeededSince: Date?
     let launchGrace: TimeInterval = 5   // settle time after launch before we may quit
     let idleQuitDelay: TimeInterval = 3 // "not needed" must persist this long before quitting
+    let stalePruneAge: TimeInterval = 1800 // drop a resting session from the list after 30 min quiet
 
     // One parsed entry per live session file (state.d/<id>.json), refreshed each tick.
     struct Session {
@@ -201,14 +267,41 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     // The poll timer runs in .common mode, so it keeps firing while the menu tracks; we use that
     // to live-update the per-session elapsed clocks. menuNeedsUpdate rebuilds the rows on each open.
-    func menuWillOpen(_ menu: NSMenu) { menuIsOpen = true }
-    func menuDidClose(_ menu: NSMenu) { menuIsOpen = false; sessionMenuItems.removeAll() }
+    func menuWillOpen(_ menu: NSMenu) {
+        menuIsOpen = true
+        spinTimer?.invalidate()
+        let t = Timer(timeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in self?.spinTick() }
+        RunLoop.main.add(t, forMode: .common)  // .common so it fires during menu tracking
+        spinTimer = t
+    }
+    func menuDidClose(_ menu: NSMenu) {
+        menuIsOpen = false
+        sessionMenuItems.removeAll()
+        spinTimer?.invalidate(); spinTimer = nil
+    }
 
-    // Re-title the open dropdown's session rows so their timers tick. Rows whose session ended
-    // freeze at their last value until the menu is reopened (the list itself is rebuilt on open).
-    func refreshOpenMenuTimers() {
+    // Advance the spinner and repaint only the working-state rows' leading icons.
+    func spinTick() {
+        spinAngle += 5   // 30fps * 5° = 150°/s ≈ 0.42 rev/s, a calm spin
+        guard let img = rotatedSpinner(spinAngle) else { return }
+        let now = Date().timeIntervalSince1970
         for (item, id) in sessionMenuItems {
-            if let s = sessions[id] { item.title = sessionMenuLine(s) }
+            guard let s = sessions[id] else { continue }
+            let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
+            if eff == "thinking" || eff == "tool" { item.image = img }
+        }
+    }
+
+    // Re-render the open dropdown's session rows each tick: timer text AND status icon, so a state
+    // change while the menu is open (working -> permission, working -> done) updates without a reopen.
+    // The session SET only changes on reopen (NSMenu can't add/remove rows reliably mid-track).
+    func refreshOpenMenuRows() {
+        let now = Date().timeIntervalSince1970
+        for (item, id) in sessionMenuItems {
+            guard let s = sessions[id] else { continue }
+            let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
+            item.attributedTitle = sessionMenuAttributed(s)
+            item.image = sessionSymbol(s, eff: eff)
         }
     }
 
@@ -216,17 +309,20 @@ final class StatusController: NSObject, NSMenuDelegate {
         menu.removeAllItems()
         checkForUpdate() // refreshes the update cache for next open (gated to once a day)
 
-        let openItem = NSMenuItem(title: "Open Claude", action: #selector(openClaude), keyEquivalent: "")
-        openItem.target = self
-        menu.addItem(openItem)
-        menu.addItem(.separator())
-
         sessionMenuItems.removeAll()
         if !sessions.isEmpty {
             menu.addItem(header("Sessions"))
             for s in sessions.values.sorted(by: { $0.ts > $1.ts }) {
-                let it = NSMenuItem(title: sessionMenuLine(s), action: nil, keyEquivalent: "")
-                it.isEnabled = false
+                let it = NSMenuItem(title: "", action: #selector(openClaude), keyEquivalent: "")
+                it.target = self
+                it.representedObject = s.id
+                it.attributedTitle = sessionMenuAttributed(s)
+                let now = Date().timeIntervalSince1970
+                it.image = sessionSymbol(s, eff: s.eff.isEmpty ? effectiveState(s, now: now) : s.eff)
+                if #available(macOS 14.0, *) {
+                    let tag = surfaceTag(s.entrypoint)
+                    if !tag.isEmpty { it.badge = NSMenuItemBadge(string: tag) }
+                }
                 menu.addItem(it)
                 sessionMenuItems.append((it, s.id))  // kept so tick() can live-update the timers
             }
@@ -235,36 +331,41 @@ final class StatusController: NSObject, NSMenuDelegate {
 
         menu.addItem(header("Options"))
 
-        let timerItem = NSMenuItem(title: "Show timer", action: #selector(toggleTimer), keyEquivalent: "")
-        timerItem.target = self
-        timerItem.state = showTimer ? .on : .off
-        menu.addItem(timerItem)
-
-        let soundItem = NSMenuItem(title: "Play Completion Sound", action: #selector(toggleSound), keyEquivalent: "")
-        soundItem.target = self
-        soundItem.state = playCompletionSound ? .on : .off
-        if #available(macOS 14.0, *) { soundItem.badge = NSMenuItemBadge(string: "1m+") }
-        menu.addItem(soundItem)
+        menu.addItem(toggleRow(title: "Show timer", isOn: showTimer) { [weak self] on in
+            self?.showTimer = on
+            UserDefaults.standard.set(on, forKey: "showTimer")
+            self?.applyTitle()
+        })
+        menu.addItem(toggleRow(title: "Completion sound (1m+)", isOn: playCompletionSound) { [weak self] on in
+            self?.playCompletionSound = on
+            UserDefaults.standard.set(on, forKey: "completionSound")
+        })
 
         menu.addItem(.separator())
-        menu.addItem(header("Animation"))
+
+        let animParent = NSMenuItem(title: "Animation Style", action: nil, keyEquivalent: "")
+        let animSub = NSMenu()
         for (style, name) in [(AnimStyle.web, "Claude Spark"), (AnimStyle.code, "Claude Code"), (AnimStyle.crab, "Crab Walking")] {
             let it = NSMenuItem(title: name, action: #selector(chooseStyle(_:)), keyEquivalent: "")
             it.target = self
             it.representedObject = style.rawValue
             it.state = animStyle == style ? .on : .off
-            menu.addItem(it)
+            animSub.addItem(it)
         }
+        animParent.submenu = animSub
+        menu.addItem(animParent)
 
-        menu.addItem(.separator())
-        menu.addItem(header("Color"))
+        let colorParent = NSMenuItem(title: "Color", action: nil, keyEquivalent: "")
+        let colorSub = NSMenu()
         for (sys, name) in [(false, "Orange"), (true, "System")] {
             let it = NSMenuItem(title: name, action: #selector(chooseColor(_:)), keyEquivalent: "")
             it.target = self
             it.representedObject = sys
             it.state = iconSystem == sys ? .on : .off
-            menu.addItem(it)
+            colorSub.addItem(it)
         }
+        colorParent.submenu = colorSub
+        menu.addItem(colorParent)
 
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Version \(currentVersion)", action: nil, keyEquivalent: ""))
@@ -273,7 +374,7 @@ final class StatusController: NSObject, NSMenuDelegate {
             up.target = self
             menu.addItem(up)
         }
-        let q = NSMenuItem(title: "Quit Claude Status Bar", action: #selector(quit), keyEquivalent: "q")
+        let q = NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q")
         q.target = self
         menu.addItem(q)
     }
@@ -285,15 +386,60 @@ final class StatusController: NSObject, NSMenuDelegate {
         return it
     }
 
-    // One (disabled, informational) menu row per live session: "project (Desktop) — Status 1m2s".
+    // An option row rendered as a custom view: label + a trailing mini NSSwitch (clicking the switch
+    // toggles and keeps the menu open). `note` is optional dim text before the switch (e.g. "1m+").
+    // The row uses autoresizing springs so the switch tracks the menu's right edge when the menu
+    // stretches the view to its full width; the switch gets a non-vibrant appearance so its "on"
+    // accent fill isn't washed out by the menu's vibrancy.
+    func toggleRow(title: String, isOn: Bool, onToggle: @escaping (Bool) -> Void) -> NSMenuItem {
+        let width: CGFloat = 280, height: CGFloat = 22, leftInset: CGFloat = 14, rightInset: CGFloat = 12
+        let row = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+        row.autoresizingMask = [.width]
+
+        let label = NSTextField(labelWithString: title)
+        label.font = .menuFont(ofSize: 0)
+        label.sizeToFit()
+        label.setFrameOrigin(NSPoint(x: leftInset, y: (height - label.frame.height) / 2))
+        label.autoresizingMask = [.maxXMargin]
+        row.addSubview(label)
+
+        let toggle = ToggleView(isOn: isOn)
+        toggle.onToggle = onToggle
+        toggle.setFrameOrigin(NSPoint(x: width - toggle.frame.width - rightInset, y: (height - toggle.frame.height) / 2))
+        toggle.autoresizingMask = [.minXMargin]
+        row.addSubview(toggle)
+
+        let item = NSMenuItem()
+        item.view = row
+        return item
+    }
+
+    // One (disabled, informational) menu row per live session: "project  Status 1m2s" + a trailing
+    // CLI/APP badge (see surfaceTag); the surface is the badge, not inline text.
     func sessionMenuLine(_ s: Session) -> String {
         let now = Date().timeIntervalSince1970
         let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff  // cached by evaluate() each tick
-        var status = statusText(s, eff: eff)
+        // The icon carries the state (spinner / amber dot / caret); the row text is just the project,
+        // plus a live timer while working since the spinner can't convey elapsed.
+        var line = truncated(sessionName(s))
         if eff == "thinking" || eff == "tool", s.startedAt > 0 {
-            status += "  " + elapsed(max(0, Int(now - s.startedAt)))
+            line += "  " + elapsed(max(0, Int(now - s.startedAt)))
         }
-        return "\(sessionName(s)) — \(status)"
+        return line
+    }
+
+    // Same as sessionMenuLine but the trailing timer is dimmed so it reads apart from the project name.
+    func sessionMenuAttributed(_ s: Session) -> NSAttributedString {
+        let now = Date().timeIntervalSince1970
+        let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
+        let font = NSFont.menuFont(ofSize: 0)
+        let str = NSMutableAttributedString(string: truncated(sessionName(s)),
+                                            attributes: [.font: font, .foregroundColor: NSColor.labelColor])
+        if eff == "thinking" || eff == "tool", s.startedAt > 0 {
+            str.append(NSAttributedString(string: "  " + elapsed(max(0, Int(now - s.startedAt))),
+                                          attributes: [.font: font, .foregroundColor: NSColor.secondaryLabelColor]))
+        }
+        return str
     }
 
     // The state portion of a session's display, shared by the bar label and the menu/tooltip rows.
@@ -305,22 +451,85 @@ final class StatusController: NSObject, NSMenuDelegate {
         }
     }
 
-    // "project" or "project (Desktop)" — the repo plus the surface it runs in (CLI / desktop app).
+    // Just the repo/cwd; the surface (CLI/APP) renders as a trailing badge instead of inline.
     func sessionName(_ s: Session) -> String {
-        let proj = s.project.isEmpty ? "session" : s.project
-        let tag = surfaceTag(s.entrypoint)
-        return tag.isEmpty ? proj : "\(proj) (\(tag))"
+        s.project.isEmpty ? "session" : s.project
     }
 
-    // CLAUDE_CODE_ENTRYPOINT -> a short human tag.
+    // CLAUDE_CODE_ENTRYPOINT -> a short all-caps badge tag.
     func surfaceTag(_ entrypoint: String) -> String {
         switch entrypoint {
         case "cli":                       return "CLI"
-        case "claude-desktop":            return "Desktop"
-        case "vscode", "vscode-insiders": return "VS Code"
+        case "claude-desktop":            return "APP"
+        case "vscode", "vscode-insiders": return "VS CODE"
         case "":                          return ""
-        default:                          return entrypoint
+        default:                          return entrypoint.uppercased()
         }
+    }
+
+    // Leading status icon for a session row. Working states spin (progress.indicator on macOS 15+,
+    // rays below); permission is amber (mirrors the bar dot); resting states are dimmed.
+    func sessionSymbol(_ s: Session, eff: String) -> NSImage? {
+        switch eff {
+        case "permission":       return symbolImage("exclamationmark.circle.fill", tint: amber)
+        case "thinking", "tool": return rotatedSpinner(spinAngle)
+        default:                 return restingCaret   // done/idle merged: dim "ready for input" caret
+        }
+    }
+
+    // The shell-style prompt caret (U+276F, what Claude Code shows when idle), dimmed and centered in
+    // a square that matches the spinner gutter so the resting rows align with the working ones.
+    lazy var restingCaret: NSImage? = {
+        let glyph = "\u{276F}" as NSString
+        let font = NSFont.systemFont(ofSize: 11, weight: .medium)
+        let side = spinnerBase?.size.width ?? 15
+        return NSImage(size: NSSize(width: side, height: side), flipped: false) { _ in
+            let attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: NSColor.tertiaryLabelColor]
+            let g = glyph.size(withAttributes: attrs)
+            glyph.draw(at: NSPoint(x: (side - g.width) / 2, y: (side - g.height) / 2), withAttributes: attrs)
+            return true
+        }
+    }()
+
+    // Pre-rendered into a padded SQUARE canvas with the glyph centered, so rotation pivots on the
+    // visual center (an off-center pivot makes the spinner orbit/wobble instead of spinning in place).
+    lazy var spinnerBase: NSImage? = {
+        let name: String
+        if #available(macOS 15.0, *) { name = "progress.indicator" } else { name = "rays" }
+        let cfg = NSImage.SymbolConfiguration(pointSize: 13, weight: .regular)
+        guard let sym = NSImage(systemSymbolName: name, accessibilityDescription: nil)?.withSymbolConfiguration(cfg) else { return nil }
+        let side = ceil(max(sym.size.width, sym.size.height)) + 2
+        let img = NSImage(size: NSSize(width: side, height: side), flipped: false) { _ in
+            sym.draw(in: NSRect(x: (side - sym.size.width) / 2, y: (side - sym.size.height) / 2,
+                                width: sym.size.width, height: sym.size.height))
+            return true
+        }
+        img.isTemplate = true
+        return img
+    }()
+
+    func rotatedSpinner(_ angleDeg: CGFloat) -> NSImage? {
+        guard let base = spinnerBase else { return nil }
+        let size = base.size
+        let img = NSImage(size: size, flipped: false) { rect in
+            guard let ctx = NSGraphicsContext.current?.cgContext else { return false }
+            ctx.translateBy(x: size.width / 2, y: size.height / 2)
+            ctx.rotate(by: -angleDeg * .pi / 180)
+            ctx.translateBy(x: -size.width / 2, y: -size.height / 2)
+            base.draw(in: rect)
+            return true
+        }
+        img.isTemplate = true
+        return img
+    }
+
+    func symbolImage(_ name: String, tint: NSColor? = nil) -> NSImage? {
+        guard let img = NSImage(systemSymbolName: name, accessibilityDescription: nil) else { return nil }
+        if let tint = tint, #available(macOS 12.0, *) {
+            return img.withSymbolConfiguration(NSImage.SymbolConfiguration(paletteColors: [tint]))
+        }
+        img.isTemplate = true
+        return img
     }
 
     // Keep the bar narrow: over `max` chars, show the first `keep` + an ellipsis (full text stays in the tooltip).
@@ -359,16 +568,6 @@ final class StatusController: NSObject, NSMenuDelegate {
         }
     }
 
-    @objc func toggleTimer() {
-        showTimer.toggle()
-        UserDefaults.standard.set(showTimer, forKey: "showTimer")
-        applyTitle()
-    }
-
-    @objc func toggleSound() {
-        playCompletionSound.toggle()
-        UserDefaults.standard.set(playCompletionSound, forKey: "completionSound")
-    }
 
     @objc func chooseColor(_ sender: NSMenuItem) {
         guard let sys = sender.representedObject as? Bool else { return }
@@ -392,7 +591,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         checkLifecycle()
         reloadSessions()
         evaluate()
-        if menuIsOpen { refreshOpenMenuTimers() }
+        if menuIsOpen { refreshOpenMenuRows() }
     }
 
     // The .json session files currently in state.d/ (ignores the .tmp files mid-write).
@@ -432,6 +631,12 @@ final class StatusController: NSObject, NSMenuDelegate {
         for id in Array(sessions.keys) {
             guard var s = sessions[id] else { continue }
             s.eff = effectiveState(s, now: now)   // compute once per tick; the menu + tooltip reuse it
+            if s.eff == "idle", now - s.ts > stalePruneAge {
+                // genuinely-quiet resting session: drop it. update.js rewrites the file if it acts again.
+                try? FileManager.default.removeItem(atPath: (stateDir as NSString).appendingPathComponent(id + ".json"))
+                sessions[id] = nil; fileMTimes[id + ".json"] = nil; soundPrev[id] = nil; turnStart[id] = nil
+                continue
+            }
             sessions[id] = s
             if soundEdgeDone(s, now: now) { chime = true }
         }
@@ -449,10 +654,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         guard let lead = lead else { renderResting(); return }
         switch lead.eff {
         case "permission":
-            // Name the blocked repo so you know WHICH session needs you (truncated; full name in tooltip).
-            let base = statusText(lead, eff: lead.eff)
-            let lbl = lead.project.isEmpty ? base : "\(truncated(lead.project)) · \(base)"
-            render(label: lbl, color: amber, animate: false, startedAt: 0, dot: true)
+            render(label: statusText(lead, eff: lead.eff), color: amber, animate: false, startedAt: 0, dot: true)
         case "thinking", "tool":
             render(label: statusText(lead, eff: lead.eff), color: iconColor, animate: true, startedAt: lead.startedAt)
         default:
@@ -467,8 +669,9 @@ final class StatusController: NSObject, NSMenuDelegate {
     // hook, freezing the file). "done" collapses to rest. Full rationale in CLAUDE.md.
     func effectiveState(_ s: Session, now: Double) -> String {
         if s.state == "thinking" || s.state == "tool" || s.state == "permission" {
-            if now - s.ts > 900 { return "idle" }                       // absolute safety net
-            if !s.transcript.isEmpty, let last = lastLine(ofFileAt: s.transcript),
+            let cap: Double = s.state == "permission" ? 7200 : 900
+            if now - s.ts > cap { return "idle" }
+            if !s.transcript.isEmpty, let last = lastTurnLine(ofFileAt: s.transcript),
                last.contains("interrupted by user") { return "idle" }
             return s.state
         }
@@ -520,6 +723,21 @@ final class StatusController: NSObject, NSMenuDelegate {
         try? fh.seek(toOffset: size > chunk ? size - chunk : 0)
         guard let data = try? fh.readToEnd(), let s = String(data: data, encoding: .utf8) else { return nil }
         return s.split(separator: "\n").last { !$0.isEmpty }.map(String.init)
+    }
+
+    // Last actual turn line (a user/assistant message), ignoring the bookkeeping lines Claude Code
+    // appends after an interrupt (system/away_summary, last-prompt, ai-title, mode, permission-mode).
+    // Those would otherwise hide the "interrupted by user" marker and freeze the amber dot.
+    func lastTurnLine(ofFileAt path: String) -> String? {
+        guard let fh = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? fh.close() }
+        let size = (try? fh.seekToEnd()) ?? 0
+        let chunk: UInt64 = 8192
+        try? fh.seek(toOffset: size > chunk ? size - chunk : 0)
+        guard let data = try? fh.readToEnd(), let s = String(data: data, encoding: .utf8) else { return nil }
+        return s.split(separator: "\n").last {
+            $0.contains("\"type\":\"user\"") || $0.contains("\"type\":\"assistant\"")
+        }.map(String.init)
     }
 
     // MARK: render

--- a/build.sh
+++ b/build.sh
@@ -23,8 +23,8 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
   <key>CFBundleDisplayName</key><string>Claude Status Bar</string>
   <key>CFBundleIdentifier</key><string>com.local.claudestatusbar</string>
   <key>CFBundleExecutable</key><string>ClaudeStatusBar</string>
-  <key>CFBundleVersion</key><string>0.2.2</string>
-  <key>CFBundleShortVersionString</key><string>0.2.2</string>
+  <key>CFBundleVersion</key><string>0.3.0</string>
+  <key>CFBundleShortVersionString</key><string>0.3.0</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>LSMinimumSystemVersion</key><string>12.0</string>
   <key>LSUIElement</key><true/>

--- a/build.sh
+++ b/build.sh
@@ -9,10 +9,15 @@ BIN="$APP/Contents/MacOS/ClaudeStatusBar"
 rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS"
 
-echo "Compiling…"
-# Pin the deployment target, else swiftc stamps the binary with the build machine's OS
-# (e.g. macOS 26), making it refuse to launch on older systems despite LSMinimumSystemVersion.
-swiftc -O -target arm64-apple-macos12.0 Sources/*.swift -o "$BIN" -framework Cocoa
+echo "Compiling universal binary (arm64 + x86_64)…"
+# Universal binary so it runs natively on both Apple Silicon and Intel (each Mac uses its own
+# slice, so Rosetta is never involved). swiftc emits one arch per -target, so this is two
+# compiles joined by lipo. Keep the deployment target pinned, else swiftc stamps the binary
+# with the build machine's OS and it refuses to launch on older systems despite LSMinimumSystemVersion.
+swiftc -O -target arm64-apple-macos12.0  Sources/*.swift -o "$BIN.arm64"  -framework Cocoa
+swiftc -O -target x86_64-apple-macos12.0 Sources/*.swift -o "$BIN.x86_64" -framework Cocoa
+lipo -create "$BIN.arm64" "$BIN.x86_64" -output "$BIN"
+rm -f "$BIN.arm64" "$BIN.x86_64"
 
 cat > "$APP/Contents/Info.plist" <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -24,6 +24,9 @@ if (fs.existsSync(oldAgentPlist)) { fs.rmSync(oldAgentPlist); console.log("Remov
 
 fs.mkdirSync(sbDir, { recursive: true });
 fs.rmSync(path.join(sbDir, "watcher.sh"), { force: true });
+// Retire pre-multi-session artifacts (single global state + empty liveness markers).
+fs.rmSync(path.join(sbDir, "state.json"), { force: true });
+fs.rmSync(path.join(sbDir, "sessions.d"), { recursive: true, force: true });
 fs.copyFileSync(path.join(__dirname, "update.js"), updateDest);
 fs.copyFileSync(path.join(__dirname, "lifecycle.js"), lifecycleDest);
 

--- a/hooks/lifecycle.js
+++ b/hooks/lifecycle.js
@@ -46,7 +46,7 @@ function run() {
     // Seed an idle file: counts the session immediately, and clears any frozen state from a
     // resume (SessionStart fires on resume with no active turn). Replaces the old clearStaleState.
     try {
-      writeAtomic(statePath, { state: "idle", label: "", tool: "", project: cwd ? path.basename(cwd) : "", sessionId: id, transcript: "", entrypoint: process.env.CLAUDE_CODE_ENTRYPOINT || "", startedAt: 0, ts: Math.floor(Date.now() / 1000) });
+      writeAtomic(statePath, { state: "idle", label: "", tool: "", project: cwd ? path.basename(cwd) : "", sessionId: id, transcript: "", entrypoint: process.env.CLAUDE_CODE_ENTRYPOINT || "", term_program: process.env.TERM_PROGRAM || "", startedAt: 0, ts: Math.floor(Date.now() / 1000) });
     } catch {}
     cp.spawn("open", ["-g", "-b", BUNDLE_ID], { stdio: "ignore", detached: true }).unref();
   } else if (event === "end") {

--- a/hooks/lifecycle.js
+++ b/hooks/lifecycle.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-// SessionStart/SessionEnd: launch the app, and track sessions as one file per session id
-// in sessions.d/ (race-free; the app quits itself). Rationale + history in CLAUDE.md.
+// SessionStart/SessionEnd: launch the app, and track each session as one file under
+// state.d/<session_id>.json (race-free; the app aggregates them and quits itself when none
+// remain). Rationale + history in CLAUDE.md.
 // Usage: node lifecycle.js <start|end>   (hook JSON, incl. session_id, arrives on stdin)
 
 const fs = require("fs");
@@ -11,29 +12,19 @@ const cp = require("child_process");
 const BUNDLE_ID = "com.local.claudestatusbar";
 const EXEC = "ClaudeStatusBar";
 const dir = path.join(os.homedir(), ".claude", "statusbar");
-const sessDir = path.join(dir, "sessions.d");
-const statePath = path.join(dir, "state.json");
+const stateDir = path.join(dir, "state.d");
 const event = process.argv[2];
 
-fs.mkdirSync(sessDir, { recursive: true });
+fs.mkdirSync(stateDir, { recursive: true });
 
 const running = () => { try { cp.execSync(`pgrep -x ${EXEC}`, { stdio: "ignore" }); return true; } catch { return false; } };
 const safeId = (s) => String(s || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64) || "unknown";
 
-// Reset a frozen animation when its OWNING session ends/resumes (force-quit fires SessionEnd
-// but no Stop). The session-id gate is load-bearing: warmup-churn bursts must not clear a live
-// turn. Full rationale in CLAUDE.md.
-function clearStaleState(id) {
-  try {
-    const prev = JSON.parse(fs.readFileSync(statePath, "utf8"));
-    if (safeId(prev.sessionId) !== id) return;
-    if (!["thinking", "tool", "permission"].includes(prev.state)) return;
-    const out = { ...prev, state: "idle", label: "", startedAt: 0, ts: Math.floor(Date.now() / 1000) };
-    const tmp = statePath + "." + process.pid + ".tmp";
-    fs.writeFileSync(tmp, JSON.stringify(out));
-    fs.renameSync(tmp, statePath);
-  } catch {}
-}
+const writeAtomic = (file, obj) => {
+  const tmp = file + "." + process.pid + ".tmp";
+  fs.writeFileSync(tmp, JSON.stringify(obj));
+  fs.renameSync(tmp, file);
+};
 
 let input = "", done = false;
 process.stdin.on("data", (d) => (input += d));
@@ -43,20 +34,25 @@ setTimeout(run, 1000); // hooks always pipe stdin, but never hang the session
 
 function run() {
   if (done) return; done = true;
-  let id = "";
-  try { id = JSON.parse(input).session_id; } catch {}
+  let id = "", cwd = "";
+  try { const j = JSON.parse(input); id = j.session_id; cwd = j.cwd || ""; } catch {}
   id = safeId(id);
+  const statePath = path.join(stateDir, id + ".json");
 
   if (event === "start") {
     // If the app isn't running, any leftover session files are stale (e.g. a prior
     // crash) — clear them so the count starts honest.
-    if (!running()) { try { for (const f of fs.readdirSync(sessDir)) fs.rmSync(path.join(sessDir, f), { force: true }); } catch {} }
-    try { fs.writeFileSync(path.join(sessDir, id), ""); } catch {}
-    clearStaleState(id);
+    if (!running()) { try { for (const f of fs.readdirSync(stateDir)) fs.rmSync(path.join(stateDir, f), { force: true }); } catch {} }
+    // Seed an idle file: counts the session immediately, and clears any frozen state from a
+    // resume (SessionStart fires on resume with no active turn). Replaces the old clearStaleState.
+    try {
+      writeAtomic(statePath, { state: "idle", label: "", tool: "", project: cwd ? path.basename(cwd) : "", sessionId: id, transcript: "", entrypoint: process.env.CLAUDE_CODE_ENTRYPOINT || "", startedAt: 0, ts: Math.floor(Date.now() / 1000) });
+    } catch {}
     cp.spawn("open", ["-g", "-b", BUNDLE_ID], { stdio: "ignore", detached: true }).unref();
   } else if (event === "end") {
-    try { fs.rmSync(path.join(sessDir, id), { force: true }); } catch {}
-    clearStaleState(id);
+    // Removing the file drops this session from the aggregate — this is also what recovers a
+    // frozen animation on force-quit (SessionEnd fires, but no Stop). No state rewrite needed.
+    try { fs.rmSync(statePath, { force: true }); } catch {}
   }
   process.exit(0);
 }

--- a/hooks/update.js
+++ b/hooks/update.js
@@ -89,7 +89,10 @@ process.stdin.on("end", () => {
   // CLAUDE_CODE_ENTRYPOINT tags the surface running this session ("cli", "claude-desktop", …);
   // carried over from prev for the odd event where the env var isn't set.
   const entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT || prev.entrypoint || "";
-  const out = { state, label, tool: p.tool_name || "", project, sessionId: p.session_id || "", transcript: p.transcript_path || prev.transcript || "", entrypoint, startedAt, ts };
+  // TERM_PROGRAM identifies the terminal app for a CLI session (Apple_Terminal, iTerm.app,
+  // vscode, WezTerm, …); the app uses it to bring that terminal to the front on a row click.
+  const termProgram = process.env.TERM_PROGRAM || prev.term_program || "";
+  const out = { state, label, tool: p.tool_name || "", project, sessionId: p.session_id || "", transcript: p.transcript_path || prev.transcript || "", entrypoint, term_program: termProgram, startedAt, ts };
   try {
     fs.mkdirSync(stateDir, { recursive: true });
     const tmp = statePath + "." + process.pid + ".tmp";

--- a/hooks/update.js
+++ b/hooks/update.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 // Invoked by Claude Code hooks. Reads the hook JSON payload on stdin, maps the
-// event to a status, and atomically writes ~/.claude/statusbar/state.json.
+// event to a status, and atomically writes a PER-SESSION file:
+//   ~/.claude/statusbar/state.d/<session_id>.json
+// The app reads every file in state.d/ and aggregates them (see Sources/main.swift).
 // Usage: node update.js <prompt|pre|post|notify|permreq|stop>
 
 const fs = require("fs");
@@ -8,7 +10,7 @@ const os = require("os");
 const path = require("path");
 
 const dir = path.join(os.homedir(), ".claude", "statusbar");
-const statePath = path.join(dir, "state.json");
+const stateDir = path.join(dir, "state.d");
 const event = process.argv[2] || "";
 
 const TOOL_LABELS = {
@@ -17,6 +19,8 @@ const TOOL_LABELS = {
   WebFetch: "Browsing web", WebSearch: "Searching web", Task: "Delegating",
   TodoWrite: "Planning",
 };
+
+const safeId = (s) => String(s || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64) || "unknown";
 
 let raw = "";
 process.stdin.on("data", (d) => (raw += d));
@@ -33,17 +37,13 @@ process.stdin.on("end", () => {
     } catch {}
   }
 
-  // Register the session here too, so a session that predates the hook install (never
-  // fired SessionStart) still gets tracked once it does anything. See CLAUDE.md gotcha.
-  const sid = String(p.session_id || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64);
-  if (sid) {
-    try {
-      const sessDir = path.join(dir, "sessions.d");
-      fs.mkdirSync(sessDir, { recursive: true });
-      fs.writeFileSync(path.join(sessDir, sid), "");
-    } catch {}
-  }
+  // This session's own file is the unit of state AND the liveness marker. Writing it on any
+  // event also tracks sessions that predate the hook install (never fired SessionStart).
+  const sid = safeId(p.session_id);
+  const statePath = path.join(stateDir, sid + ".json");
 
+  // Read THIS session's prior state (not a shared global) so startedAt/transcript carry over
+  // within the session and never bleed across concurrent sessions.
   let prev = {};
   try { prev = JSON.parse(fs.readFileSync(statePath, "utf8")); } catch {}
 
@@ -86,9 +86,12 @@ process.stdin.on("end", () => {
       return;
   }
 
-  const out = { state, label, tool: p.tool_name || "", project, sessionId: p.session_id || "", transcript: p.transcript_path || prev.transcript || "", startedAt, ts };
+  // CLAUDE_CODE_ENTRYPOINT tags the surface running this session ("cli", "claude-desktop", …);
+  // carried over from prev for the odd event where the env var isn't set.
+  const entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT || prev.entrypoint || "";
+  const out = { state, label, tool: p.tool_name || "", project, sessionId: p.session_id || "", transcript: p.transcript_path || prev.transcript || "", entrypoint, startedAt, ts };
   try {
-    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
     const tmp = statePath + "." + process.pid + ".tmp";
     fs.writeFileSync(tmp, JSON.stringify(out));
     fs.renameSync(tmp, statePath);


### PR DESCRIPTION
> **Versioning note:** this bumps the app version 0.2.2 → 0.3.0 so existing installs re-run hook installation and pick up the new per-session hooks. Let me know if you'd rather own version bumps yourself — happy to drop that change.

Implements the multi-session support from #8 (where this started), adopting the priority + naming approach from #11.

### What's new
- **Per-session state + aggregation.** Each session writes its own `~/.claude/statusbar/state.d/<id>.json` instead of all sessions sharing one file; the app reads them all and renders a single icon. This fixes the last-writer-wins behavior — a finished session no longer rests the icon while another is still working, and sessions can't inherit each other's timer.
- **Highest-priority session surfaced** (from #11). The bar shows the most important session — permission > working > idle, ties broken by recency — so one awaiting your approval is never hidden behind one merely thinking. The permission label names the blocked repo (`api · Awaiting permission`, truncated when long).
- **Per-session dropdown + live timers.** The menu lists every live session as `project — status`, and each elapsed clock ticks live while the menu is open.
- **CLI vs desktop tag.** Each session records `CLAUDE_CODE_ENTRYPOINT`, so the dropdown rows and the hover tooltip show whether it's running in the CLI or the desktop app (e.g. `claude-status-bar (Desktop)`).

Per-session recovery (Esc interrupt via the transcript marker, force-quit via `SessionEnd`, and a staleness guard) is preserved.
