### PR TITLE
Add multi-session support: xN count in menu bar, per-session state, aggregated menu, Priority setting

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "displayName": "Claude Status Bar",
       "source": "./",
       "description": "Menu bar indicator for Claude Code: animated spark, elapsed timer, and open/close lifecycle.",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "homepage": "https://github.com/m1ckc3s/claude-status-bar",
       "license": "MIT"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-status-bar",
   "description": "Menu bar status indicator for Claude Code: animated spark, elapsed timer, and open/close lifecycle.",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "homepage": "https://github.com/m1ckc3s/claude-status-bar",
   "license": "MIT"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to Claude Status Bar are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [0.2.3] - 2026-06-25
+
+### Added
+- **Multi-session support.** With several Claude Code sessions running at once, the menu bar now tracks all of them instead of silently overwriting one with another. State is tracked per session (`sessions.d/<id>.json`). The icon and label follow the **most-recently-active** session — it animates while that session works, or shows the amber dot the moment that session needs permission — so the bar always reflects what you're currently doing instead of getting stuck on a background session.
+- A **×N count** appears in the menu bar when two or more sessions are active, so you always know how many are running even when only one is in the label.
+- A new **Sessions** section in the menu lists all your recent Claude sessions — each by its title (Claude Code's auto-generated session name, the same one on your terminal tab), what it's doing (or *Idle*), and elapsed time — with a small dot (amber = awaiting permission, orange = working, muted = idle) that echoes the menu-bar icon. The `×N` count reflects only the actively-working sessions. A session that hasn't done anything in 15 minutes drops off automatically, so a closed or crashed tab can't linger.
+- A **Priority** setting controls which session leads the menu bar when several are active: *Most recent* (default, per #8) or *Awaiting permission* first (so a session blocked on your approval is never hidden behind one that's merely working). The Sessions list and `×N` count are unaffected either way.
+
+### Changed
+- The single global `state.json` is retired in favor of one file per session. Existing recovery paths (Esc interrupt, denied permission, force-quit, stale state) now apply per session. Upgrades migrate automatically.
+
+### Fixed
+- A session that finished a turn **without running any tool** no longer lingers as a stuck "Thinking…". The `Stop` hook doesn't always fire on a no-tool turn, so the status would freeze on thinking; now a thinking session drops to idle once it has gone quiet on *both* its hooks and its transcript for ~2 minutes (an active Agent or a long streaming answer keeps one of those fresh, so a busy session is never affected).
+- The per-session **timers in the Sessions menu tick live** while the menu is open, instead of freezing the moment you clicked.
+
 ## [0.2.2] - 2026-06-25
 
 ### Fixed

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,22 +1,44 @@
 import Cocoa
 
+// One session's status, parsed from ~/.claude/statusbar/sessions.d/<id>.json.
+struct SessionState {
+    var state: String
+    var label: String
+    var project: String
+    var title: String       // Claude Code's ai-title (the terminal-tab name); falls back to project
+    var sessionId: String
+    var transcript: String
+    var startedAt: Double
+    var ts: Double
+    var name: String { !title.isEmpty ? title : (project.isEmpty ? "session" : project) }
+}
+
 final class StatusController: NSObject, NSMenuDelegate {
     let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-    let statePath = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/statusbar/state.json")
     let sessionsDir = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/statusbar/sessions.d")
     let claudeDesktopBundleID = "com.anthropic.claudefordesktop"
 
-    var lastMTime: Date = .distantPast
+    var lastSig = ""           // signature of sessions.d (names + mtimes); reload only on change
     var pollTimer: Timer?
     var animTimer: Timer?
     var frameIdx = 0
+    var menuRefreshTimer: Timer?                        // ticks the open menu's session clocks
+    var menuRowItems: [(NSMenuItem, SessionState)] = [] // open-menu rows, for the live refresh
 
     let launchedAt = Date()
     var notNeededSince: Date?
     let launchGrace: TimeInterval = 5   // settle time after launch before we may quit
     let idleQuitDelay: TimeInterval = 3 // "not needed" must persist this long before quitting
+    let staleAfter: TimeInterval = 900  // a session not seen in 15 min is recovered to idle AND
+                                        // dropped from the menu, so a crashed/closed tab can't linger
+    let thinkingIdleAfter: TimeInterval = 120 // treat a "thinking" session as finished only when BOTH
+                                              // its last hook (ts) AND its transcript have been quiet
+                                              // this long — either being fresh means it's still working
+                                              // (an Agent keeps firing hooks; a long answer streams)
 
-    var current: [String: Any] = [:]
+    var rawSessions: [SessionState] = []      // last parsed snapshot of sessions.d/*.json
+    var displaySessions: [SessionState] = []  // active (working/permission), most-recent first
+    var activeCount = 0
     var activeBase = ""        // label without the elapsed clock
     var startedAt: Double = 0  // unix seconds the current turn began (0 = no clock)
     var activeColor: NSColor? = nil
@@ -28,6 +50,10 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     enum AnimStyle: String { case web, code, crab }
     var animStyle: AnimStyle = .web
+    // Which session leads the menu bar when several are active: the most-recently-active one
+    // (per issue #8), or any awaiting permission first (so a blocked session is never hidden).
+    enum PriorityMode: String { case recent, permission }
+    var priorityMode: PriorityMode = .recent
     var showTimer = false
     var iconSystem = false // false = brand Orange; true = adaptive black/white (template image)
     var playCompletionSound = false // chime when a turn longer than ~1 min finishes
@@ -37,8 +63,8 @@ final class StatusController: NSObject, NSMenuDelegate {
         s.volume = 0.7 // the clip is loud at full system volume; play it a bit softer
         return s
     }()
-    var prevEff = ""               // last effective state, for detecting turn completion
-    var lastTurnStart: Double = 0  // active turn's start time, for the 1-minute gate
+    var turnStarts: [String: Double] = [:]  // per-session turn start, for the 1-min completion chime
+    var workingLast: Set<String> = []       // sessions working on the previous tick (chime edge-detect)
     var iconColor: NSColor? { iconSystem ? nil : brand } // nil => render as an adaptive template
     let codeGlyphs = ["✻", "✽", "✶", "✳", "✢"]
     let codePeaks: [CGFloat] = [1.0, 1.0, 1.0, 1.0, 1.0]
@@ -70,6 +96,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         if d.object(forKey: "iconSystem") != nil { iconSystem = d.bool(forKey: "iconSystem") }
         if d.object(forKey: "completionSound") != nil { playCompletionSound = d.bool(forKey: "completionSound") }
         if let s = d.string(forKey: "animStyle"), let st = AnimStyle(rawValue: s) { animStyle = st }
+        if let p = d.string(forKey: "priorityMode"), let pm = PriorityMode(rawValue: p) { priorityMode = pm }
         let menu = NSMenu()
         menu.delegate = self
         statusItem.menu = menu
@@ -187,7 +214,22 @@ final class StatusController: NSObject, NSMenuDelegate {
         let openItem = NSMenuItem(title: "Open Claude", action: #selector(openClaude), keyEquivalent: "")
         openItem.target = self
         menu.addItem(openItem)
+
         menu.addItem(.separator())
+
+        // Sessions roster: every recent session (active first, then idle), most-recent within each.
+        menuRowItems.removeAll()
+        if !displaySessions.isEmpty {
+            menu.addItem(header(displaySessions.count >= 2 ? "Sessions · \(displaySessions.count)" : "Sessions"))
+            let now = Date().timeIntervalSince1970
+            for s in displaySessions {
+                let it = sessionRow(s, now: now)
+                menuRowItems.append((it, s)) // remember rows so the open menu can tick them live
+                menu.addItem(it)
+            }
+            menu.addItem(.separator())
+        }
+
         menu.addItem(header("Options"))
 
         let timerItem = NSMenuItem(title: "Show timer", action: #selector(toggleTimer), keyEquivalent: "")
@@ -200,6 +242,16 @@ final class StatusController: NSObject, NSMenuDelegate {
         soundItem.state = playCompletionSound ? .on : .off
         if #available(macOS 14.0, *) { soundItem.badge = NSMenuItemBadge(string: "1m+") }
         menu.addItem(soundItem)
+
+        menu.addItem(.separator())
+        menu.addItem(header("Priority"))
+        for (mode, name) in [(PriorityMode.recent, "Most recent"), (PriorityMode.permission, "Awaiting permission")] {
+            let it = NSMenuItem(title: name, action: #selector(choosePriority(_:)), keyEquivalent: "")
+            it.target = self
+            it.representedObject = mode.rawValue
+            it.state = priorityMode == mode ? .on : .off
+            menu.addItem(it)
+        }
 
         menu.addItem(.separator())
         menu.addItem(header("Animation"))
@@ -233,11 +285,81 @@ final class StatusController: NSObject, NSMenuDelegate {
         menu.addItem(q)
     }
 
+    // NSMenu builds its items once on open and never rebuilds while shown, so the per-session
+    // clocks (and the bar clock) would freeze. Tick them every second while the menu is open.
+    func menuWillOpen(_ menu: NSMenu) {
+        let t = Timer(timeInterval: 1.0, repeats: true) { [weak self] _ in self?.refreshOpenMenu() }
+        RunLoop.main.add(t, forMode: .common)
+        RunLoop.main.add(t, forMode: .eventTracking) // status-item menus track in this mode
+        menuRefreshTimer = t
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+        menuRefreshTimer?.invalidate(); menuRefreshTimer = nil
+        menuRowItems.removeAll()
+    }
+
+    func refreshOpenMenu() {
+        let now = Date().timeIntervalSince1970
+        for (item, s) in menuRowItems { item.attributedTitle = sessionRowTitle(s, now: now) }
+        applyTitle() // keep the menu-bar clock live while the menu is open, too
+        statusItem.button?.needsDisplay = true
+    }
+
     func header(_ title: String) -> NSMenuItem {
         if #available(macOS 14.0, *) { return NSMenuItem.sectionHeader(title: title) }
         let it = NSMenuItem(title: title, action: nil, keyEquivalent: "")
         it.isEnabled = false
         return it
+    }
+
+    // One "project · verb  1m 2s" row, with a leading state-colored dot that echoes the
+    // menu-bar icon. action:nil => auto-disabled + dimmed, matching the Version row.
+    func sessionRow(_ s: SessionState, now: Double) -> NSMenuItem {
+        let it = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        let working = s.state == "thinking" || s.state == "tool"
+        let isPerm = s.state == "permission"
+        // Dot echoes the menu-bar language: amber = awaiting permission, orange = working, muted = idle.
+        let dotColor: NSColor = isPerm ? amber : (working ? (iconColor ?? .secondaryLabelColor) : .tertiaryLabelColor)
+        it.image = sessionDot(dotColor)
+        it.attributedTitle = sessionRowTitle(s, now: now)
+        return it
+    }
+
+    // The row's text (name · verb · elapsed clock). Split out so the OPEN menu can re-render the
+    // live clock every second — NSMenu builds its items only on open, so without this the timers
+    // freeze the moment you click the menu.
+    func sessionRowTitle(_ s: SessionState, now: Double) -> NSAttributedString {
+        let working = s.state == "thinking" || s.state == "tool"
+        let isPerm = s.state == "permission"
+        let line = NSMutableAttributedString()
+        let name = s.name.count > 34 ? String(s.name.prefix(33)) + "…" : s.name
+        line.append(NSAttributedString(string: name,
+            attributes: [.foregroundColor: NSColor.labelColor]))
+        let verb = isPerm ? "Awaiting permission" : (working ? (s.label.isEmpty ? "Working" : s.label) : "Idle")
+        line.append(NSAttributedString(string: "  ·  \(verb)",
+            attributes: [.foregroundColor: NSColor.secondaryLabelColor]))
+        if working, s.startedAt > 0 { // only a running session shows the elapsed clock
+            let secs = max(0, Int(now - s.startedAt)), m = secs / 60, sec = secs % 60
+            let clk = m > 0 ? "\(m)m \(sec)s" : "\(sec)s"
+            line.append(NSAttributedString(string: "   \(clk)", attributes: [
+                .foregroundColor: NSColor.tertiaryLabelColor,
+                .font: NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular),
+            ]))
+        }
+        return line
+    }
+
+    // Small filled dot (amber = permission, orange/system = working) shown before a session row.
+    func sessionDot(_ color: NSColor) -> NSImage {
+        let s: CGFloat = 10, d: CGFloat = 7
+        let img = NSImage(size: NSSize(width: s, height: s), flipped: false) { _ in
+            color.setFill()
+            NSBezierPath(ovalIn: NSRect(x: (s - d) / 2, y: (s - d) / 2, width: d, height: d)).fill()
+            return true
+        }
+        img.isTemplate = false
+        return img
     }
 
     @objc func quit() { NSApp.terminate(nil) }
@@ -264,7 +386,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         guard let sys = sender.representedObject as? Bool else { return }
         iconSystem = sys
         UserDefaults.standard.set(iconSystem, forKey: "iconSystem")
-        evaluate() // re-render the current state in the new color
+        aggregate() // re-render the current state in the new color
     }
 
     @objc func chooseStyle(_ sender: NSMenuItem) {
@@ -273,64 +395,137 @@ final class StatusController: NSObject, NSMenuDelegate {
         UserDefaults.standard.set(raw, forKey: "animStyle")
         animTimer?.invalidate(); animTimer = nil // recreate at the new style's fps
         frameIdx = 0
-        evaluate()
+        aggregate()
+    }
+
+    @objc func choosePriority(_ sender: NSMenuItem) {
+        guard let raw = sender.representedObject as? String, let pm = PriorityMode(rawValue: raw) else { return }
+        priorityMode = pm
+        UserDefaults.standard.set(raw, forKey: "priorityMode")
+        aggregate()
     }
 
     // MARK: state polling
 
     func tick() {
         checkLifecycle()
-        let fm = FileManager.default
-        guard let attrs = try? fm.attributesOfItem(atPath: statePath),
-              let m = attrs[.modificationDate] as? Date else {
-            evaluate(); return
-        }
-        if m != lastMTime {
-            lastMTime = m
-            if let data = fm.contents(atPath: statePath),
-               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                current = obj
-            }
-        }
-        evaluate()
+        let sig = sessionsSignature()
+        if sig != lastSig { lastSig = sig; rawSessions = loadSessions() }
+        // aggregate() runs every tick (not just on change): the transcript-marker recovery and
+        // the live elapsed clock advance on time, not on a session-file write.
+        aggregate()
     }
 
-    func evaluate() {
-        let state = current["state"] as? String ?? "idle"
-        var label = current["label"] as? String ?? ""
-        let ts = (current["ts"] as? NSNumber)?.doubleValue ?? 0
-        let started = (current["startedAt"] as? NSNumber)?.doubleValue ?? 0
-        let age = Date().timeIntervalSince1970 - ts
+    // "Hash of dir listing + per-file mtime": cheap signature so we re-read sessions.d only
+    // when a session file appears, disappears, or changes. *.tmp atomic-write files are ignored.
+    func sessionsSignature() -> String {
+        let fm = FileManager.default
+        guard let names = try? fm.contentsOfDirectory(atPath: sessionsDir) else { return "" }
+        var parts: [String] = []
+        for n in names.filter({ $0.hasSuffix(".json") }).sorted() {
+            let p = (sessionsDir as NSString).appendingPathComponent(n)
+            let m = ((try? fm.attributesOfItem(atPath: p))?[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+            parts.append("\(n):\(m)")
+        }
+        return parts.joined(separator: "|")
+    }
 
-        var eff = state
-        // Stop fires on normal completion but NOT on an Esc interrupt or a denied permission
-        // prompt: Claude Code writes "[Request interrupted by user]" to the transcript and ends
-        // with no hook, freezing state.json. Recover off that marker. (Force-quit writes no
-        // marker; lifecycle.js handles that case.) Full rationale in CLAUDE.md.
-        if state == "thinking" || state == "tool" || state == "permission" {
-            if age > 900 { eff = "idle"; label = "" } // absolute safety net
-            else if let tr = current["transcript"] as? String,
-                    let last = lastLine(ofFileAt: tr),
-                    last.contains("interrupted by user") {
-                eff = "idle"; label = ""
+    func loadSessions() -> [SessionState] {
+        let fm = FileManager.default
+        guard let names = try? fm.contentsOfDirectory(atPath: sessionsDir) else { return [] }
+        var out: [SessionState] = []
+        for n in names where n.hasSuffix(".json") {
+            let p = (sessionsDir as NSString).appendingPathComponent(n)
+            guard let data = fm.contents(atPath: p),
+                  let o = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
+            out.append(SessionState(
+                state: o["state"] as? String ?? "idle",
+                label: o["label"] as? String ?? "",
+                project: o["project"] as? String ?? "",
+                title: o["title"] as? String ?? "",
+                sessionId: o["sessionId"] as? String ?? n,
+                transcript: o["transcript"] as? String ?? "",
+                startedAt: (o["startedAt"] as? NSNumber)?.doubleValue ?? 0,
+                ts: (o["ts"] as? NSNumber)?.doubleValue ?? 0))
+        }
+        return out
+    }
+
+    // Per-session recovery. The Stop hook fires on normal completion but NOT on an Esc interrupt,
+    // a denied permission prompt, OR (commonly) a turn that answers without running any tool — so
+    // a session can sit frozen on "thinking" with no event to clear it. Recover three ways:
+    //  1. absolute 15-min staleness net (covers force-quit / any frozen state),
+    //  2. transcript marker "interrupted by user" (Esc / denied prompt),
+    //  3. a "thinking" session that has gone quiet on BOTH signals — no hook event (ts) AND no
+    //     transcript write — for thinkingIdleAfter. Either being fresh means it's still working: an
+    //     Agent/tool burst keeps firing hooks (fresh ts), and a long no-tool answer streams to the
+    //     transcript (fresh mtime). ("tool" is exempt: a long command does neither while it runs.)
+    func recover(_ s: SessionState) -> SessionState {
+        var s = s
+        guard ["thinking", "tool", "permission"].contains(s.state) else { return s }
+        let now = Date().timeIntervalSince1970
+        if now - s.ts > staleAfter { s.state = "idle"; s.label = ""; return s }
+        if s.state == "thinking", now - s.ts > thinkingIdleAfter, !s.transcript.isEmpty,
+           let attrs = try? FileManager.default.attributesOfItem(atPath: s.transcript),
+           let m = attrs[.modificationDate] as? Date,
+           now - m.timeIntervalSince1970 > thinkingIdleAfter {
+            s.state = "idle"; s.label = ""; return s
+        }
+        if let last = lastLine(ofFileAt: s.transcript), last.contains("interrupted by user") {
+            s.state = "idle"; s.label = ""
+        }
+        return s
+    }
+
+    // Aggregate every session into one menu-bar presentation.
+    func aggregate() {
+        let now = Date().timeIntervalSince1970
+        let sessions = rawSessions.map(recover)
+
+        let working = sessions.filter { $0.state == "thinking" || $0.state == "tool" }
+        func isActive(_ s: SessionState) -> Bool { ["thinking", "tool", "permission"].contains(s.state) }
+        // "Active" = working or awaiting permission (the attention-worthy states); drives the bar + count.
+        let active = sessions.filter(isActive).sorted { ($0.ts, $0.startedAt) > ($1.ts, $1.startedAt) }
+        activeCount = active.count
+
+        // Menu roster: EVERY session seen in the last `staleAfter` seconds (idle included), active
+        // ones first then most-recent idle. The age filter drops a crashed/closed tab so it can't
+        // linger as a ghost row.
+        displaySessions = sessions
+            .filter { now - $0.ts < staleAfter }
+            .filter { isActive($0) || !$0.title.isEmpty || !$0.project.isEmpty } // hide nameless just-started sessions
+            .sorted { (isActive($0) ? 1 : 0, $0.ts) > (isActive($1) ? 1 : 0, $1.ts) }
+
+        // Completion chime: per-session, fires once when a turn that ran >= 1 min leaves "working".
+        if playCompletionSound {
+            let nowWorking = Set(working.map { $0.sessionId })
+            for w in working where w.startedAt > 0 { turnStarts[w.sessionId] = w.startedAt }
+            for id in workingLast where !nowWorking.contains(id) {
+                if let start = turnStarts[id], now - start >= 60 { completionSound?.play() }
+                turnStarts[id] = nil
             }
+            workingLast = nowWorking
+        } else {
+            turnStarts.removeAll(); workingLast.removeAll()
         }
 
-        // Chime once when a turn that ran >= 1 min transitions to "done".
-        if (eff == "thinking" || eff == "tool"), started > 0 { lastTurnStart = started }
-        if eff == "done", prevEff != "done", playCompletionSound,
-           lastTurnStart > 0, Date().timeIntervalSince1970 - lastTurnStart >= 60 {
-            completionSound?.play()
-        }
-        if eff == "done" { lastTurnStart = 0 }
-        prevEff = eff
-
-        switch eff {
-        case "thinking":  render(label: label.isEmpty ? "Thinking…" : label, color: iconColor, animate: true,  startedAt: started)
-        case "tool":      render(label: label.isEmpty ? "Working…"  : label, color: iconColor, animate: true,  startedAt: started)
-        case "permission":render(label: "Awaiting permission", color: amber, animate: false, startedAt: 0, dot: true)
-        case "waiting":   render(label: label.isEmpty ? "Waiting" : label, color: iconColor, animate: false, startedAt: 0)
-        default:          render(label: "", color: iconColor, animate: false, startedAt: 0) // done + idle: just the orange spark
+        // Which session leads the bar (Priority setting):
+        //  • .recent — the most-recently-active session, whatever its state (per issue #8). A
+        //    fresh permission request briefly leads and flashes "Awaiting permission"; as soon as
+        //    you work elsewhere that session's ts overtakes it and the bar follows your work.
+        //  • .permission — any session awaiting permission wins (most-recent among them), so a
+        //    blocked session is never hidden behind one that's merely working.
+        // Either way the ×N badge counts active sessions and idle ones stay in the Sessions list.
+        let lead = (priorityMode == .permission ? active.first(where: { $0.state == "permission" }) : nil) ?? active.first
+        if let lead = lead {
+            if lead.state == "permission" {
+                render(label: "Awaiting permission", color: amber, animate: false, startedAt: 0, dot: true)
+            } else {
+                let label = lead.label.isEmpty ? (lead.state == "tool" ? "Working…" : "Thinking…") : lead.label
+                render(label: label, color: iconColor, animate: true, startedAt: lead.startedAt)
+            }
+        } else {
+            render(label: "", color: iconColor, animate: false, startedAt: 0) // all idle/done: resting spark
         }
     }
 
@@ -341,7 +536,10 @@ final class StatusController: NSObject, NSMenuDelegate {
     }
 
     func sessionCount() -> Int {
-        (try? FileManager.default.contentsOfDirectory(atPath: sessionsDir).count) ?? 0
+        // Count every session marker except in-flight *.tmp atomic writes. Legacy empty
+        // markers (pre-upgrade) still count, so a pre-existing session keeps the app alive.
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: sessionsDir) else { return 0 }
+        return names.filter { !$0.hasSuffix(".tmp") }.count
     }
 
     // Stay while Claude desktop is open OR a session is active; otherwise quit after a
@@ -403,25 +601,34 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     func applyTitle() {
         guard let button = statusItem.button else { return }
+        let mono = NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular)
         var text = activeBase
         if showTimer, startedAt > 0 {
             let secs = max(0, Int(Date().timeIntervalSince1970 - startedAt))
             let m = secs / 60, s = secs % 60
             text += "  " + (m > 0 ? "\(m)m \(s)s" : "\(s)s") // Claude Code style: "1m 1s" / "43s"
         }
-        if text.isEmpty {
+        // A whisper-quiet "×N" when 2+ sessions are active — restraint over a loud badge.
+        let badge = activeCount >= 2 ? "×\(activeCount)" : ""
+        if text.isEmpty && badge.isEmpty {
             button.imagePosition = .imageOnly
             button.attributedTitle = NSAttributedString(string: "")
             return
         }
         button.imagePosition = .imageLeading
-        // labelColor adapts: white on a dark menu bar, black on a light one. Monospaced
-        // digits keep the elapsed clock from nudging neighboring menu bar icons.
-        let attrs: [NSAttributedString.Key: Any] = [
-            .foregroundColor: NSColor.labelColor,
-            .font: NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular),
-        ]
-        button.attributedTitle = NSAttributedString(string: " \(text)", attributes: attrs)
+        // labelColor adapts (white on a dark menu bar, black on a light one); the count uses the
+        // same color as the label so it reads as one consistent unit. Monospaced digits keep
+        // widths from nudging neighboring menu bar icons.
+        let title = NSMutableAttributedString()
+        if !text.isEmpty {
+            title.append(NSAttributedString(string: " \(text)",
+                attributes: [.foregroundColor: NSColor.labelColor, .font: mono]))
+        }
+        if !badge.isEmpty {
+            title.append(NSAttributedString(string: "\(text.isEmpty ? " " : "  ")\(badge)",
+                attributes: [.foregroundColor: NSColor.labelColor, .font: mono]))
+        }
+        button.attributedTitle = title
     }
 
     // MARK: icon

--- a/build.sh
+++ b/build.sh
@@ -23,8 +23,8 @@ cat > "$APP/Contents/Info.plist" <<'PLIST'
   <key>CFBundleDisplayName</key><string>Claude Status Bar</string>
   <key>CFBundleIdentifier</key><string>com.local.claudestatusbar</string>
   <key>CFBundleExecutable</key><string>ClaudeStatusBar</string>
-  <key>CFBundleVersion</key><string>0.2.2</string>
-  <key>CFBundleShortVersionString</key><string>0.2.2</string>
+  <key>CFBundleVersion</key><string>0.2.3</string>
+  <key>CFBundleShortVersionString</key><string>0.2.3</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>LSMinimumSystemVersion</key><string>12.0</string>
   <key>LSUIElement</key><true/>

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -24,6 +24,7 @@ if (fs.existsSync(oldAgentPlist)) { fs.rmSync(oldAgentPlist); console.log("Remov
 
 fs.mkdirSync(sbDir, { recursive: true });
 fs.rmSync(path.join(sbDir, "watcher.sh"), { force: true });
+fs.rmSync(path.join(sbDir, "state.json"), { force: true }); // retire the legacy single global state file (0.3.0+: per-session files)
 fs.copyFileSync(path.join(__dirname, "update.js"), updateDest);
 fs.copyFileSync(path.join(__dirname, "lifecycle.js"), lifecycleDest);
 

--- a/hooks/lifecycle.js
+++ b/hooks/lifecycle.js
@@ -12,26 +12,36 @@ const BUNDLE_ID = "com.local.claudestatusbar";
 const EXEC = "ClaudeStatusBar";
 const dir = path.join(os.homedir(), ".claude", "statusbar");
 const sessDir = path.join(dir, "sessions.d");
-const statePath = path.join(dir, "state.json");
 const event = process.argv[2];
 
 fs.mkdirSync(sessDir, { recursive: true });
 
 const running = () => { try { cp.execSync(`pgrep -x ${EXEC}`, { stdio: "ignore" }); return true; } catch { return false; } };
 const safeId = (s) => String(s || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64) || "unknown";
+const sessFileFor = (id) => path.join(sessDir, id + ".json");
 
-// Reset a frozen animation when its OWNING session ends/resumes (force-quit fires SessionEnd
-// but no Stop). The session-id gate is load-bearing: warmup-churn bursts must not clear a live
-// turn. Full rationale in CLAUDE.md.
+// Reset a frozen animation left by a force-quit (which fires SessionEnd but no Stop, so the
+// file survives in an active state). The file IS the session now, so no id gate is needed —
+// on a normal SessionEnd the file is already deleted and this is a no-op. See CLAUDE.md.
 function clearStaleState(id) {
+  const f = sessFileFor(id);
   try {
-    const prev = JSON.parse(fs.readFileSync(statePath, "utf8"));
-    if (safeId(prev.sessionId) !== id) return;
+    const prev = JSON.parse(fs.readFileSync(f, "utf8"));
     if (!["thinking", "tool", "permission"].includes(prev.state)) return;
     const out = { ...prev, state: "idle", label: "", startedAt: 0, ts: Math.floor(Date.now() / 1000) };
-    const tmp = statePath + "." + process.pid + ".tmp";
+    const tmp = f + "." + process.pid + ".tmp";
     fs.writeFileSync(tmp, JSON.stringify(out));
-    fs.renameSync(tmp, statePath);
+    fs.renameSync(tmp, f);
+  } catch {}
+}
+
+// Seed an idle file so an open-but-idle session still counts toward the app-liveness refcount.
+function writeIdle(id) {
+  try {
+    fs.writeFileSync(sessFileFor(id), JSON.stringify({
+      state: "idle", label: "", tool: "", project: "",
+      sessionId: id, transcript: "", startedAt: 0, ts: Math.floor(Date.now() / 1000),
+    }));
   } catch {}
 }
 
@@ -49,14 +59,14 @@ function run() {
 
   if (event === "start") {
     // If the app isn't running, any leftover session files are stale (e.g. a prior
-    // crash) — clear them so the count starts honest.
+    // crash) — clear them so the count starts honest. This also sweeps any legacy empty
+    // markers left from before the multi-session upgrade.
     if (!running()) { try { for (const f of fs.readdirSync(sessDir)) fs.rmSync(path.join(sessDir, f), { force: true }); } catch {} }
-    try { fs.writeFileSync(path.join(sessDir, id), ""); } catch {}
-    clearStaleState(id);
+    if (!fs.existsSync(sessFileFor(id))) writeIdle(id); // count an open, idle session
+    clearStaleState(id);                                // on resume, clear a frozen leftover
     cp.spawn("open", ["-g", "-b", BUNDLE_ID], { stdio: "ignore", detached: true }).unref();
   } else if (event === "end") {
-    try { fs.rmSync(path.join(sessDir, id), { force: true }); } catch {}
-    clearStaleState(id);
+    try { fs.rmSync(sessFileFor(id), { force: true }); } catch {} // deletion IS the cleanup
   }
   process.exit(0);
 }

--- a/hooks/update.js
+++ b/hooks/update.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // Invoked by Claude Code hooks. Reads the hook JSON payload on stdin, maps the
-// event to a status, and atomically writes ~/.claude/statusbar/state.json.
+// event to a status, and atomically writes one file per session at
+// ~/.claude/statusbar/sessions.d/<session_id>.json (the app aggregates them all).
 // Usage: node update.js <prompt|pre|post|notify|permreq|stop>
 
 const fs = require("fs");
@@ -8,8 +9,30 @@ const os = require("os");
 const path = require("path");
 
 const dir = path.join(os.homedir(), ".claude", "statusbar");
-const statePath = path.join(dir, "state.json");
+const sessDir = path.join(dir, "sessions.d");
 const event = process.argv[2] || "";
+const safeId = (s) => String(s || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64);
+
+// Claude Code writes an auto-generated "ai-title" into the session transcript — the same
+// human-friendly name shown on the terminal tab. Tail the end of the transcript to grab the
+// latest one cheaply (no full-file read; transcripts can be many MB).
+function readAiTitle(tp) {
+  if (!tp) return "";
+  try {
+    const fd = fs.openSync(tp, "r");
+    const size = fs.fstatSync(fd).size;
+    const start = size > 65536 ? size - 65536 : 0;
+    const buf = Buffer.alloc(size - start);
+    fs.readSync(fd, buf, 0, buf.length, start);
+    fs.closeSync(fd);
+    let title = "";
+    for (const line of buf.toString("utf8").split("\n")) {
+      if (line.indexOf('"ai-title"') === -1) continue; // cheap pre-filter before JSON.parse
+      try { const j = JSON.parse(line); if (j.type === "ai-title" && j.aiTitle) title = j.aiTitle; } catch {}
+    }
+    return title;
+  } catch { return ""; }
+}
 
 const TOOL_LABELS = {
   Bash: "Running command", Edit: "Editing", Write: "Writing", MultiEdit: "Editing",
@@ -33,21 +56,32 @@ process.stdin.on("end", () => {
     } catch {}
   }
 
-  // Register the session here too, so a session that predates the hook install (never
-  // fired SessionStart) still gets tracked once it does anything. See CLAUDE.md gotcha.
-  const sid = String(p.session_id || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64);
-  if (sid) {
-    try {
-      const sessDir = path.join(dir, "sessions.d");
-      fs.mkdirSync(sessDir, { recursive: true });
-      fs.writeFileSync(path.join(sessDir, sid), "");
-    } catch {}
-  }
+  const sid = safeId(p.session_id) || "unknown";
+  const sessFile = path.join(sessDir, sid + ".json");
 
+  // Read THIS session's previous state (per-session now, not the old single global file)
+  // to preserve startedAt/transcript/project across hook calls within a turn. The
+  // per-session transcript is load-bearing for denied-permission recovery — see CLAUDE.md.
   let prev = {};
-  try { prev = JSON.parse(fs.readFileSync(statePath, "utf8")); } catch {}
+  try { prev = JSON.parse(fs.readFileSync(sessFile, "utf8")); } catch {}
+
+  // Register the session on ANY activity (even an unhandled event), so a session that
+  // predates the hook install (never fired SessionStart) still counts toward the app's
+  // liveness refcount and renders. Seed an idle file if none exists yet.
+  try {
+    fs.mkdirSync(sessDir, { recursive: true });
+    if (!fs.existsSync(sessFile)) {
+      fs.writeFileSync(sessFile, JSON.stringify({
+        state: "idle", label: "", tool: "", project: prev.project || "", title: prev.title || "",
+        sessionId: p.session_id || "", transcript: prev.transcript || "",
+        startedAt: 0, ts: Math.floor(Date.now() / 1000),
+      }));
+    }
+  } catch {}
 
   const project = p.cwd ? path.basename(p.cwd) : prev.project || "";
+  // Cache the title once found (it's stable) so we don't tail the transcript on every event.
+  const title = prev.title || readAiTitle(p.transcript_path) || "";
   const ts = Math.floor(Date.now() / 1000);
   let state = "idle", label = "", startedAt = prev.startedAt || 0;
 
@@ -86,11 +120,11 @@ process.stdin.on("end", () => {
       return;
   }
 
-  const out = { state, label, tool: p.tool_name || "", project, sessionId: p.session_id || "", transcript: p.transcript_path || prev.transcript || "", startedAt, ts };
+  const out = { state, label, tool: p.tool_name || "", project, title, sessionId: p.session_id || "", transcript: p.transcript_path || prev.transcript || "", startedAt, ts };
   try {
-    fs.mkdirSync(dir, { recursive: true });
-    const tmp = statePath + "." + process.pid + ".tmp";
+    fs.mkdirSync(sessDir, { recursive: true });
+    const tmp = sessFile + "." + process.pid + ".tmp"; // .tmp suffix is ignored by the app
     fs.writeFileSync(tmp, JSON.stringify(out));
-    fs.renameSync(tmp, statePath);
+    fs.renameSync(tmp, sessFile);
   } catch {}
 });


### PR DESCRIPTION
## Multi-session support

Implements the multi-session design from #8.

Today every session writes one shared `~/.claude/statusbar/state.json`, so with several Claude Code sessions running the menu bar just follows whichever wrote last. This makes each session write its own `sessions.d/<id>.json` and has the app read and aggregate all of them.

### Behavior
- **Most-recently-active wins the bar** — it animates while that session works, or shows the amber dot the moment any session needs permission, then follows your work again.
- A **Priority** setting (in the menu) switches between *Most recent* (default, per #8) and *Awaiting permission first* — so if you'd rather a blocked session always surface over one that's merely working, you can.
- A **×N** count of actively-working sessions in the menu bar.
- A new **Sessions** menu section listing each recent session by its Claude Code title (the terminal-tab name, read from the transcript's `ai-title`), with a state dot (amber = permission, orange = working, muted = idle), what it's doing or `Idle`, and a live elapsed clock that keeps ticking while the menu is open.

### Reliability
- Per-session recovery: the Esc-interrupt transcript marker, a 15-min staleness net, and force-quit cleanup now apply per session; a closed/crashed tab drops off automatically.
- A turn that answers **without running any tool** sometimes ends with no `Stop` hook, which used to freeze the session on "thinking". A thinking session whose transcript goes quiet for 30s now drops to idle (tools are exempt — a long command legitimately writes nothing while it runs).

### Compatibility
- The single global `state.json` is retired (`install.js` removes it on upgrade); legacy empty `sessions.d/<id>` markers are ignored gracefully.
- **Hook event wiring is unchanged** — same events, same `install.js` / `hooks.json`. Only what the hooks write and what the app reads changed.
- Bumped to 0.2.3; CHANGELOG updated.

### Testing
Built with `./build.sh` and run on macOS with multiple concurrent real sessions plus synthetic fixtures: both Priority modes, most-recent-wins label/timer, the `×N` count, idle rows, session titles, live menu clocks, and all recovery paths (stale, Esc-interrupt, and the no-`Stop` no-tool turn).

<img width="500" height="581" alt="Screenshot 2026-06-26 at 12 14 25 AM" src="https://github.com/user-attachments/assets/341d3d34-f064-41bc-bf09-f9f2da0e5efc" />

<img width="426" height="585" alt="Screenshot 2026-06-26 at 12 13 12 AM" src="https://github.com/user-attachments/assets/a38fbd57-2bf3-4ed0-895c-820bd647c49e" />
