### PR TITLE
feat: add Claude usage meter and reorganize the menu

### DIFF
--- a/Sources/AppSettings.swift
+++ b/Sources/AppSettings.swift
@@ -1,0 +1,42 @@
+import Cocoa
+
+enum ColorTheme: String { case claude, system, mono }            // key statusColorTheme, default claude
+enum UsageScope: String { case session, week, urgent }           // key usageWindow, default urgent
+enum UsageDisplay: String { case bar, dot, percent, off }        // key usageDisplay, default bar; off hides the menu-bar widget
+
+// Single source of truth for all global prefs. NSObject so it can be the target of its
+// own @objc menu actions. didSet persists + broadcasts; observers never run during init,
+// so the initial reads below do no write-back.
+final class AppSettings: NSObject {
+    static let shared = AppSettings()
+
+    private let d: UserDefaults
+
+    var refreshIntervalMinutes: Int  { didSet { d.set(refreshIntervalMinutes, forKey: "refreshIntervalMinutes"); onChange?() } }
+    var launchAtLogin: Bool          { didSet { d.set(launchAtLogin, forKey: "launchAtLogin"); onChange?() } }
+    var statusColorTheme: ColorTheme { didSet { d.set(statusColorTheme.rawValue, forKey: "statusColorTheme"); onChange?() } }
+    var usageWindow: UsageScope      { didSet { d.set(usageWindow.rawValue, forKey: "usageWindow"); onChange?() } }
+    var usageDisplay: UsageDisplay   { didSet { d.set(usageDisplay.rawValue, forKey: "usageDisplay"); onChange?() } }
+
+    // Controllers chain into this so BOTH widgets re-render after any setter writes.
+    var onChange: (() -> Void)?
+
+    // defaults is injectable purely so the self-test can use an isolated suite.
+    init(defaults: UserDefaults = .standard) {
+        d = defaults
+        // object(forKey:) presence test keeps "real default" distinct from a stored 0/false.
+        refreshIntervalMinutes = d.object(forKey: "refreshIntervalMinutes") != nil ? d.integer(forKey: "refreshIntervalMinutes") : 5
+        launchAtLogin          = d.object(forKey: "launchAtLogin") != nil ? d.bool(forKey: "launchAtLogin") : true
+        statusColorTheme       = ColorTheme(rawValue: d.string(forKey: "statusColorTheme") ?? "") ?? .claude
+        usageWindow            = UsageScope(rawValue: d.string(forKey: "usageWindow") ?? "") ?? .urgent
+        usageDisplay           = UsageDisplay(rawValue: d.string(forKey: "usageDisplay") ?? "") ?? .bar
+        super.init()
+    }
+
+    // MARK: @objc menu action (reads sender.representedObject, then writes a setter)
+
+    @objc func chooseRefreshInterval(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String, let v = Int(key) else { return }
+        refreshIntervalMinutes = v
+    }
+}

--- a/Sources/Credentials.swift
+++ b/Sources/Credentials.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+struct OAuthToken {
+    var accessToken: String
+    var expiresAt: Date?
+
+    // No expiry known (e.g. an env-provided token) counts as still valid: v1 never refreshes
+    // tokens itself, so "expired" exists only to drive the Re-login state.
+    func isExpired(now: Date) -> Bool {
+        guard let expiresAt else { return false }
+        return now >= expiresAt
+    }
+}
+
+enum CredentialResolver {
+    static func resolve(env: [String: String], home: URL, configDir: URL?, runSecurity: () -> String?) -> OAuthToken? {
+        // 1. Environment override wins outright.
+        if let raw = env["CLAUDE_CODE_OAUTH_TOKEN"], !raw.isEmpty {
+            return OAuthToken(accessToken: raw, expiresAt: nil)
+        }
+
+        // 2. Credentials file (Linux/WSL location; usually absent on macOS). Honor $CLAUDE_CONFIG_DIR.
+        let base = configDir ?? home.appendingPathComponent(".claude")
+        let fileURL = base.appendingPathComponent(".credentials.json")
+        if let data = try? Data(contentsOf: fileURL), let token = parse(data) {
+            return token
+        }
+
+        // 3. macOS Keychain, read through the injected `security` subprocess.
+        if let raw = runSecurity(), let data = raw.data(using: .utf8), let token = parse(data) {
+            return token
+        }
+
+        return nil
+    }
+
+    // expiresAt is epoch milliseconds in both the file and the Keychain payload.
+    private static func parse(_ data: Data) -> OAuthToken? {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let oauth = root["claudeAiOauth"] as? [String: Any],
+              let access = oauth["accessToken"] as? String, !access.isEmpty else { return nil }
+        var expires: Date?
+        if let ms = (oauth["expiresAt"] as? NSNumber)?.doubleValue { expires = Date(timeIntervalSince1970: ms / 1000) }
+        return OAuthToken(accessToken: access, expiresAt: expires)
+    }
+}
+
+enum SecurityKeychain {
+    static let service = "Claude Code-credentials"
+
+    // `/usr/bin/security` has been observed to hang indefinitely on recent macOS, so we run it
+    // under a hard deadline and kill it on timeout. MUST be called off the main thread
+    // (UsageStore runs it inside its refresh worker).
+    static func readToken(timeout: TimeInterval) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        // -a scopes the lookup to this login user's item (what the Claude Code CLI stores under).
+        process.arguments = ["find-generic-password", "-s", service, "-a", NSUserName(), "-w"]
+
+        let outPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = FileHandle.nullDevice
+
+        guard (try? process.run()) != nil else { return nil }
+
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            group.leave()
+        }
+
+        if group.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()
+            _ = group.wait(timeout: .now() + 0.5) // brief grace, then force-kill
+            if process.isRunning { kill(process.processIdentifier, SIGKILL) }
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else { return nil }
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let raw = (String(data: data, encoding: .utf8) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return raw.isEmpty ? nil : raw
+    }
+}

--- a/Sources/LocalUsageEstimator.swift
+++ b/Sources/LocalUsageEstimator.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+enum LocalUsageEstimator {
+    static func estimate(projectsDir: URL, now: Date) -> (today: Int, week: Int) {
+        let fm = FileManager.default
+        guard let walker = fm.enumerator(at: projectsDir,
+                                         includingPropertiesForKeys: [.contentModificationDateKey]) else {
+            return (0, 0)
+        }
+
+        let cal = Calendar.current
+        let startOfToday = cal.startOfDay(for: now)
+        let startOfWeek = mostRecentMonday(onOrBefore: now, calendar: cal)
+
+        var seen = Set<String>()
+        var today = 0
+        var week = 0
+
+        for case let url as URL in walker where url.pathExtension == "jsonl" {
+            // Transcripts are append-only, so a file last modified before the week boundary
+            // holds no in-window entries — skip it without reading (avoids re-parsing all history).
+            if let mtime = try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate,
+               mtime < startOfWeek { continue }
+            guard let data = fm.contents(atPath: url.path),
+                  let text = String(data: data, encoding: .utf8) else { continue }
+
+            for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+                guard let lineData = line.data(using: .utf8),
+                      let obj = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                      let message = obj["message"] as? [String: Any],
+                      let usage = message["usage"] as? [String: Any] else { continue }
+
+                // Dedupe by message.id + requestId: the same assistant turn appears across
+                // multiple transcripts (resumes, sidechains). Skip dedupe only if both are absent.
+                let id = (message["id"] as? String) ?? ""
+                let req = (obj["requestId"] as? String) ?? ""
+                if !id.isEmpty || !req.isEmpty {
+                    let key = id + "|" + req
+                    if seen.contains(key) { continue }
+                    seen.insert(key)
+                }
+
+                let tokens = intToken(usage, "input_tokens")
+                    + intToken(usage, "output_tokens")
+                    + intToken(usage, "cache_creation_input_tokens")
+                    + intToken(usage, "cache_read_input_tokens")
+                if tokens == 0 { continue }
+
+                guard let ts = (obj["timestamp"] as? String).flatMap(UsageParser.parseResetDate) else { continue }
+                if ts >= startOfWeek { week += tokens }
+                if ts >= startOfToday { today += tokens }
+            }
+        }
+
+        return (today, week)
+    }
+
+    private static func intToken(_ usage: [String: Any], _ key: String) -> Int {
+        (usage[key] as? NSNumber)?.intValue ?? 0
+    }
+
+    // Most recent Monday 00:00 local (today if today is Monday). weekday: 1=Sun … 7=Sat.
+    private static func mostRecentMonday(onOrBefore now: Date, calendar: Calendar) -> Date {
+        let start = calendar.startOfDay(for: now)
+        let weekday = calendar.component(.weekday, from: start)
+        let daysSinceMonday = (weekday + 5) % 7    // Mon->0, Tue->1 … Sun->6
+        return calendar.date(byAdding: .day, value: -daysSinceMonday, to: start) ?? start
+    }
+}

--- a/Sources/LoginItem.swift
+++ b/Sources/LoginItem.swift
@@ -1,0 +1,26 @@
+import Cocoa
+import ServiceManagement
+
+// SMAppService keys a login item on the bundle's code signature AND its recorded path.
+// LaunchServices relaunches the app from /Applications, so registering from anywhere
+// else (a dev build/path) records a path macOS won't relaunch — only register from there.
+enum LoginItem {
+    private static var eligible: Bool { Bundle.main.bundlePath.hasPrefix("/Applications/") }
+
+    static func setEnabled(_ on: Bool) {
+        guard #available(macOS 13, *), eligible else { return } // no-op on macOS 12 / non-/Applications
+        do {
+            if on { try SMAppService.mainApp.register() }
+            else { try SMAppService.mainApp.unregister() }
+        } catch {
+            // Ad-hoc dev builds (changing signature each rebuild) may orphan/duplicate the
+            // entry or report .requiresApproval — expected; surface, don't crash.
+            NSLog("ClaudeStatusBar: login item \(on ? "register" : "unregister") failed: \(error)")
+        }
+    }
+
+    static var isEnabled: Bool {
+        guard #available(macOS 13, *) else { return false }
+        return SMAppService.mainApp.status == .enabled
+    }
+}

--- a/Sources/MenuBuilders.swift
+++ b/Sources/MenuBuilders.swift
@@ -1,0 +1,45 @@
+import Cocoa
+
+enum MenuBuilders {
+    // A "Foo ▸" row opening a submenu of mutually-exclusive options, checkmark on `selected`.
+    // Each option carries its key in representedObject so the @objc action can read it back.
+    static func choiceSubmenu(title: String,
+                              choices: [(label: String, key: String)],
+                              selected: String,
+                              action: Selector,
+                              target: AnyObject) -> NSMenuItem {
+        let parent = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        let sub = NSMenu()
+        for choice in choices {
+            let it = NSMenuItem(title: choice.label, action: action, keyEquivalent: "")
+            it.target = target
+            it.representedObject = choice.key
+            it.state = (choice.key == selected) ? .on : .off
+            sub.addItem(it)
+        }
+        parent.submenu = sub
+        return parent
+    }
+
+    // A toggle WITHOUT a left checkmark gutter: state stays .off so macOS reserves no gutter
+    // (which would indent every item). The indicator is a native right-aligned NSMenuItemBadge
+    // (macOS 14+) so it lines up with the system's own right-edge elements (⌘Q, submenu arrows).
+    // `rightText` is optional fixed text (e.g. "1m+"); a "✓" is added when on. Older macOS falls
+    // back to a standard left checkmark.
+    static func rightToggle(title: String,
+                            rightText: String?,
+                            checked: Bool,
+                            action: Selector,
+                            target: AnyObject) -> NSMenuItem {
+        let it = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        it.target = target
+        let badge = [rightText, checked ? "✓" : nil].compactMap { $0 }.joined(separator: " ")
+        if #available(macOS 14.0, *) {
+            if !badge.isEmpty { it.badge = NSMenuItemBadge(string: badge) }
+        } else {
+            it.state = checked ? .on : .off
+            if let rightText { it.title = "\(title) (\(rightText))" }
+        }
+        return it
+    }
+}

--- a/Sources/ProgressBarView.swift
+++ b/Sources/ProgressBarView.swift
@@ -1,0 +1,96 @@
+import Cocoa
+
+final class ProgressBarView: NSView {
+    private let title: String
+    private let utilization: Double        // 0...100
+    private let resetsAt: Date?
+    private let fillColor: NSColor?        // nil (mono) -> labelColor
+
+    init(title: String, utilization: Double, resetsAt: Date?,
+         color: NSColor?) {
+        self.title = title
+        self.utilization = max(0, min(100, utilization))
+        self.resetsAt = resetsAt
+        self.fillColor = color
+        // Widest top-level item, so the menu sizes to it and the track spans the full width.
+        // Extra height past the content leaves empty space below, spacing consecutive rows apart.
+        super.init(frame: NSRect(x: 0, y: 0, width: 290, height: 52))
+    }
+
+    // Never loaded from a nib; failable init returns nil instead of force-unwrapping.
+    required init?(coder: NSCoder) { return nil }
+
+    override var isFlipped: Bool { true } // top-left origin for straightforward top-down layout
+
+    // The OWNER (StatusController) drives live redraws: while the menu is open it runs a
+    // RunLoop.main `.common`-mode Timer and calls tick() so the reset countdown stays live.
+    func tick() { needsDisplay = true }
+}
+
+extension ProgressBarView {
+    override func draw(_ dirtyRect: NSRect) {
+        let pad: CGFloat = 12
+        let w = bounds.width
+
+        // Top row: title (left) + big percent (right)
+        let titleAttrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 12),
+            .foregroundColor: NSColor.secondaryLabelColor
+        ]
+        (title as NSString).draw(at: NSPoint(x: pad, y: 5), withAttributes: titleAttrs)
+
+        let pctText = "\(Int(utilization.rounded()))%"
+        let pctAttrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 15, weight: .semibold),
+            .foregroundColor: NSColor.labelColor
+        ]
+        let pctSize = (pctText as NSString).size(withAttributes: pctAttrs)
+        (pctText as NSString).draw(at: NSPoint(x: w - pad - pctSize.width, y: 3), withAttributes: pctAttrs)
+
+        // Track
+        let trackX = pad, trackY: CGFloat = 26, trackH: CGFloat = 5
+        let trackW = w - pad * 2
+        let track = NSRect(x: trackX, y: trackY, width: trackW, height: trackH)
+        // Higher alpha so the full-width track reads as a bar with a partial fill on a dark menu.
+        NSColor.tertiaryLabelColor.withAlphaComponent(0.4).setFill()
+        NSBezierPath(roundedRect: track, xRadius: trackH / 2, yRadius: trackH / 2).fill()
+
+        // Fill (clamp to a pill-minimum so a tiny non-zero value stays visible)
+        let fillW = trackW * CGFloat(utilization / 100)
+        if fillW > 0 {
+            let fillRect = NSRect(x: trackX, y: trackY, width: max(trackH, fillW), height: trackH)
+            (fillColor ?? NSColor.labelColor).setFill()
+            NSBezierPath(roundedRect: fillRect, xRadius: trackH / 2, yRadius: trackH / 2).fill()
+        }
+
+        // Reset countdown (left-aligned, gray to match the title, below the track)
+        let reset = ProgressBarView.formatReset(resetsAt, now: Date())
+        if !reset.isEmpty {
+            let rAttrs: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 12),
+                .foregroundColor: NSColor.secondaryLabelColor
+            ]
+            (reset as NSString).draw(at: NSPoint(x: pad, y: 33), withAttributes: rAttrs)
+        }
+    }
+}
+
+extension ProgressBarView {
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "EEE HH:mm"
+        return f
+    }()
+
+    static func formatReset(_ date: Date?, now: Date) -> String {
+        guard let date else { return "" }
+        let remaining = date.timeIntervalSince(now)
+        if remaining <= 0 { return "resetting…" }
+        if remaining < 24 * 3600 {
+            let h = Int(remaining) / 3600
+            let m = (Int(remaining) % 3600) / 60
+            return h > 0 ? "resets in \(h)h \(m)m" : "resets in \(m)m"
+        }
+        return "resets \(dayFormatter.string(from: date))"
+    }
+}

--- a/Sources/SelfTest.swift
+++ b/Sources/SelfTest.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+private var selfTestFailures = 0
+
+// Prints PASS/FAIL per check and tracks failures for the final tally.
+func expect(_ ok: Bool, _ msg: String) {
+    if ok {
+        print("PASS: \(msg)")
+    } else {
+        selfTestFailures += 1
+        print("FAIL: \(msg)")
+    }
+}
+
+func runSelfTests() -> Bool {
+    selfTestFailures = 0
+    testUsageStatus()
+    testUsageParser()
+    selfTestCredentials()
+    selfTestLocalEstimate()
+    runUsageStoreSelfTests()
+    print(selfTestFailures == 0 ? "ALL PASS" : "\(selfTestFailures) FAILED")
+    return selfTestFailures == 0
+}
+
+private func testUsageStatus() {
+    // level thresholds: <50 safe, 50..<80 warn, >=80 critical (boundaries)
+    expect(UsageStatus.level(0)    == .safe,     "level 0 -> safe")
+    expect(UsageStatus.level(49.9) == .safe,     "level 49.9 -> safe")
+    expect(UsageStatus.level(50)   == .warn,     "level 50 -> warn")
+    expect(UsageStatus.level(79.9) == .warn,     "level 79.9 -> warn")
+    expect(UsageStatus.level(80)   == .critical, "level 80 -> critical")
+    expect(UsageStatus.level(100)  == .critical, "level 100 -> critical")
+}
+
+private func testUsageParser() {
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // 0–100 JSON path: five_hour has fractional-second reset, seven_day has none.
+    let jsonText = """
+    {"five_hour":{"utilization":42,"resets_at":"2026-06-26T18:30:00.000Z"},
+     "seven_day":{"utilization":67,"resets_at":"2026-06-29T09:00:00Z"}}
+    """
+    let json = jsonText.data(using: .utf8) ?? Data()
+    let snap = UsageParser.parseUsageJSON(json, now: now)
+    expect(snap?.source == .official, "JSON source -> official")
+    expect((snap?.session?.utilization ?? -1) == 42, "JSON five_hour util -> 42")
+    expect((snap?.week?.utilization ?? -1) == 67, "JSON seven_day util -> 67")
+    expect(snap?.session?.resetsAt != nil, "JSON fractional resets_at parsed")
+    expect(snap?.week?.resetsAt != nil, "JSON non-fractional resets_at parsed")
+    expect(snap?.lastUpdated == now, "JSON lastUpdated stamped with now")
+
+    // 0.0–1.0 header path: must *100 to match the JSON scale; resets are Unix seconds.
+    let headers: [AnyHashable: Any] = [
+        "Anthropic-Ratelimit-Unified-5h-Utilization": "0.42",   // mixed case on purpose
+        "anthropic-ratelimit-unified-5h-reset": "1700001800",
+        "anthropic-ratelimit-unified-7d-utilization": "0.67",
+        "anthropic-ratelimit-unified-7d-reset": "1700100000",
+    ]
+    let hsnap = UsageParser.parseRateLimitHeaders(headers, now: now)
+    expect(hsnap?.source == .ratelimitHeaders, "header source -> ratelimitHeaders")
+    expect(abs((hsnap?.session?.utilization ?? -1) - 42) < 1e-6, "header 5h 0.42 -> 42 (case-insensitive)")
+    expect(abs((hsnap?.week?.utilization ?? -1) - 67) < 1e-6, "header 7d 0.67 -> 67")
+    expect(hsnap?.session?.resetsAt == Date(timeIntervalSince1970: 1_700_001_800), "header unix reset parsed")
+
+    // same-scale proof: header path and JSON path agree on the session window.
+    let same = abs((hsnap?.session?.utilization ?? -1) - (snap?.session?.utilization ?? -2)) < 1e-6
+    expect(same, "JSON 0–100 and header 0–1 paths land on the SAME scale")
+
+    // parseResetDate: with fractional, without fractional, and a bad string.
+    expect(UsageParser.parseResetDate("2026-06-26T18:30:00.000Z") != nil, "resetDate with fractional seconds")
+    expect(UsageParser.parseResetDate("2026-06-26T18:30:00Z") != nil, "resetDate without fractional seconds")
+    expect(UsageParser.parseResetDate("not-a-date") == nil, "resetDate bad string -> nil")
+}
+
+func selfTestCredentials() {
+    let fm = FileManager.default
+    let root = fm.temporaryDirectory.appendingPathComponent("selftest-cred-\(UUID().uuidString)")
+    let claude = root.appendingPathComponent(".claude")
+    try? fm.createDirectory(at: claude, withIntermediateDirectories: true)
+    defer { try? fm.removeItem(at: root) }
+
+    // expiresAt in the past (epoch ms): Nov 2023, safely before any test run.
+    let pastMs = 1_700_000_000_000
+    let json = "{\"claudeAiOauth\":{\"accessToken\":\"file-token-abc\",\"expiresAt\":\(pastMs)}}"
+    try? json.data(using: .utf8)?.write(to: claude.appendingPathComponent(".credentials.json"))
+
+    let now = Date()
+
+    // File token is resolved when no env override is present.
+    let fileTok = CredentialResolver.resolve(env: [:], home: root, configDir: nil, runSecurity: { nil })
+    expect(fileTok?.accessToken == "file-token-abc", "credentials: file token resolved")
+
+    // A past expiresAt (ms) marks the token expired.
+    expect(fileTok?.isExpired(now: now) == true, "credentials: past expiresAt -> isExpired true")
+
+    // Env override takes precedence over the file.
+    let envTok = CredentialResolver.resolve(env: ["CLAUDE_CODE_OAUTH_TOKEN": "env-token-xyz"],
+                                            home: root, configDir: nil, runSecurity: { nil })
+    expect(envTok?.accessToken == "env-token-xyz", "credentials: env token preferred over file")
+
+    // A future expiry reads as not expired; a missing expiry is never expired.
+    expect(OAuthToken(accessToken: "t", expiresAt: now.addingTimeInterval(3600)).isExpired(now: now) == false,
+           "credentials: future expiresAt -> not expired")
+    expect(OAuthToken(accessToken: "t", expiresAt: nil).isExpired(now: now) == false,
+           "credentials: no expiresAt -> not expired")
+}
+
+func selfTestLocalEstimate() {
+    let fm = FileManager.default
+    let root = fm.temporaryDirectory.appendingPathComponent("selftest-est-\(UUID().uuidString)")
+    let dirA = root.appendingPathComponent("projA")
+    let dirB = root.appendingPathComponent("projB/nested")
+    try? fm.createDirectory(at: dirA, withIntermediateDirectories: true)
+    try? fm.createDirectory(at: dirB, withIntermediateDirectories: true)
+    defer { try? fm.removeItem(at: root) }
+
+    let cal = Calendar.current
+    // Wednesday 2026-06-24 12:00 local; that week's Monday is 2026-06-22.
+    var nowC = DateComponents()
+    nowC.year = 2026; nowC.month = 6; nowC.day = 24; nowC.hour = 12
+    guard let now = cal.date(from: nowC) else { expect(false, "localEstimate: could not build fixture now"); return }
+
+    let iso = ISO8601DateFormatter()
+    iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+    func at(_ y: Int, _ mo: Int, _ d: Int, _ h: Int) -> Date {
+        var c = DateComponents(); c.year = y; c.month = mo; c.day = d; c.hour = h
+        return cal.date(from: c) ?? now
+    }
+    func record(id: String, req: String, at date: Date, input: Int, output: Int, cacheC: Int, cacheR: Int) -> String {
+        let ts = iso.string(from: date)
+        return "{\"timestamp\":\"\(ts)\",\"requestId\":\"\(req)\",\"message\":{\"id\":\"\(id)\",\"usage\":{"
+            + "\"input_tokens\":\(input),\"output_tokens\":\(output),"
+            + "\"cache_creation_input_tokens\":\(cacheC),\"cache_read_input_tokens\":\(cacheR)}}}"
+    }
+
+    // Today (Wed): 10+20+5+5 = 40 tokens; written twice as an exact duplicate -> counted once.
+    let todayLine = record(id: "m1", req: "r1", at: at(2026, 6, 24, 10), input: 10, output: 20, cacheC: 5, cacheR: 5)
+    let fileA = [todayLine, todayLine].joined(separator: "\n") + "\n"
+    try? fileA.data(using: .utf8)?.write(to: dirA.appendingPathComponent("s1.jsonl"))
+
+    // Tuesday (this week, not today): 100 tokens. Old (2 weeks back): 1000 tokens, outside the week.
+    let tuesLine = record(id: "m2", req: "r2", at: at(2026, 6, 23, 9), input: 100, output: 0, cacheC: 0, cacheR: 0)
+    let oldLine  = record(id: "m3", req: "r3", at: at(2026, 6, 10, 9), input: 1000, output: 0, cacheC: 0, cacheR: 0)
+    let fileB = [tuesLine, oldLine].joined(separator: "\n") + "\n"
+    try? fileB.data(using: .utf8)?.write(to: dirB.appendingPathComponent("s2.jsonl"))
+
+    let (today, week) = LocalUsageEstimator.estimate(projectsDir: root, now: now)
+    // today = 40 (duplicate collapsed); the Tuesday and old records are not today.
+    expect(today == 40, "localEstimate: today total = 40 (got \(today))")
+    // week = 40 (today) + 100 (Tuesday); the 2-week-old 1000 is excluded.
+    expect(week == 140, "localEstimate: week total = 140 (got \(week))")
+}
+
+func runUsageStoreSelfTests() {
+    // 5-minute floor decision
+    let t0 = Date(timeIntervalSince1970: 1_000_000)
+    expect(UsageStore.shouldFetch(force: false, lastFetch: t0, now: t0.addingTimeInterval(100), minRefresh: 300) == false,
+           "floor blocks a refresh 100s after last fetch")
+    expect(UsageStore.shouldFetch(force: false, lastFetch: t0, now: t0.addingTimeInterval(400), minRefresh: 300) == true,
+           "floor allows a refresh 400s after last fetch")
+    expect(UsageStore.shouldFetch(force: true, lastFetch: t0, now: t0.addingTimeInterval(1), minRefresh: 300) == true,
+           "force bypasses the 5-minute floor")
+
+    // Regression: the floor must sit BELOW the interval, or a scheduled tick (which lands a few
+    // seconds shy of the full interval, since lastFetch is stamped at completion) gets skipped —
+    // the bug that turned a 2-min setting into ~4-min.
+    let twoMinFloor = UsageStore.floor(forIntervalMinutes: 2)
+    expect(twoMinFloor < 120, "floor(2min)=\(Int(twoMinFloor))s sits below the 120s interval")
+    expect(UsageStore.shouldFetch(force: false, lastFetch: t0, now: t0.addingTimeInterval(117), minRefresh: twoMinFloor) == true,
+           "a scheduled 2-min tick (117s after last fetch) fetches with the corrected floor")
+    expect(UsageStore.shouldFetch(force: false, lastFetch: t0, now: t0.addingTimeInterval(117), minRefresh: 120) == false,
+           "regression guard: floor==interval (120s) would have skipped that 2-min tick")
+
+    // cache read/write round-trip
+    let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("ust-\(UUID().uuidString).json")
+    let snap = UsageSnapshot(
+        session: WindowUsage(utilization: 42, resetsAt: Date(timeIntervalSince1970: 1_700_000_000)),
+        week: WindowUsage(utilization: 67, resetsAt: nil),
+        localTokensToday: nil, localTokensWeek: nil,
+        source: .official,
+        lastUpdated: Date(timeIntervalSince1970: 1_699_999_000)
+    )
+    UsageStore.saveCache(snap, to: tmp)
+    expect(UsageStore.loadCache(tmp) == snap, "cache round-trips an identical UsageSnapshot")
+    try? FileManager.default.removeItem(at: tmp)
+    expect(UsageStore.loadCache(FileManager.default.temporaryDirectory.appendingPathComponent("nope-\(UUID().uuidString).json")) == nil,
+           "loadCache returns nil for a missing file")
+}

--- a/Sources/UsageColors.swift
+++ b/Sources/UsageColors.swift
@@ -1,0 +1,29 @@
+import Cocoa
+
+enum UsageColors {
+    // Muted "Claude tone" palette that sits beside the brand orange (#d97757),
+    // not systemRed/Green/Yellow. Hexes per spec §5.3.
+    private static let safe     = NSColor(srgbRed: 0x6B / 255.0, green: 0x9B / 255.0, blue: 0x6B / 255.0, alpha: 1) // #6B9B6B sage
+    private static let warn     = NSColor(srgbRed: 0xD8 / 255.0, green: 0xA2 / 255.0, blue: 0x3C / 255.0, alpha: 1) // #D8A23C amber
+    private static let critical = NSColor(srgbRed: 0xC2 / 255.0, green: 0x5B / 255.0, blue: 0x4E / 255.0, alpha: 1) // #C25B4E terracotta
+
+    // .mono -> nil: caller renders a template / labelColor for adaptive black-and-white.
+    static func color(level: UsageLevel, theme: ColorTheme) -> NSColor? {
+        switch theme {
+        case .mono:
+            return nil
+        case .system:
+            switch level {
+            case .safe: return .systemGreen
+            case .warn: return .systemYellow
+            case .critical: return .systemRed
+            }
+        case .claude:
+            switch level {
+            case .safe: return safe
+            case .warn: return warn
+            case .critical: return critical
+            }
+        }
+    }
+}

--- a/Sources/UsageModels.swift
+++ b/Sources/UsageModels.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+// String-backed so the cache encodes/decodes via rawValue (case names == the strings persisted).
+enum UsageSource: String { case official, ratelimitHeaders, signedOut, expired }
+
+// utilization is ALWAYS 0...100 after parsing (header path multiplies 0.0–1.0 by 100).
+struct WindowUsage: Equatable {
+    var utilization: Double
+    var resetsAt: Date?
+}
+
+struct UsageSnapshot: Equatable {
+    var session: WindowUsage?      // five_hour
+    var week: WindowUsage?         // seven_day
+    var localTokensToday: Int?     // set on the no-token (.signedOut) path
+    var localTokensWeek: Int?
+    var source: UsageSource
+    var lastUpdated: Date
+}
+
+enum UsageLevel { case safe, warn, critical }     // used%: <50 safe, 50..<80 warn, >=80 critical
+
+enum UsageStatus {
+    static func level(_ utilization: Double) -> UsageLevel {
+        switch utilization {
+        case ..<50:  return .safe
+        case ..<80:  return .warn
+        default:     return .critical
+        }
+    }
+}

--- a/Sources/UsageParser.swift
+++ b/Sources/UsageParser.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+enum UsageParser {
+    // /oauth/usage body: { "five_hour": {utilization 0–100, resets_at ISO-8601}, "seven_day": {...} }
+    static func parseUsageJSON(_ data: Data, now: Date) -> UsageSnapshot? {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        let session = jsonWindow(obj["five_hour"])
+        let week = jsonWindow(obj["seven_day"])
+        guard session != nil || week != nil else { return nil }
+        return UsageSnapshot(session: session, week: week,
+                             localTokensToday: nil, localTokensWeek: nil,
+                             source: .official, lastUpdated: now)
+    }
+
+    // Messages-API rate-limit headers: unified-5h/7d-utilization are 0.0–1.0 (->*100);
+    // -reset are Unix seconds.
+    static func parseRateLimitHeaders(_ headers: [AnyHashable: Any], now: Date) -> UsageSnapshot? {
+        let lower = normalize(headers)
+        let session = headerWindow(lower,
+                                   utilKey: "anthropic-ratelimit-unified-5h-utilization",
+                                   resetKey: "anthropic-ratelimit-unified-5h-reset")
+        let week = headerWindow(lower,
+                                utilKey: "anthropic-ratelimit-unified-7d-utilization",
+                                resetKey: "anthropic-ratelimit-unified-7d-reset")
+        guard session != nil || week != nil else { return nil }
+        return UsageSnapshot(session: session, week: week,
+                             localTokensToday: nil, localTokensWeek: nil,
+                             source: .ratelimitHeaders, lastUpdated: now)
+    }
+
+    // Fractional seconds first; the API has omitted them before, so fall back to plain
+    // internet-date-time (a single hard formatter would silently fail on the other shape).
+    // Cached statics: this runs once per transcript line in the local-estimate scan and
+    // ISO8601DateFormatter init is expensive. Also the single canonical ISO-8601 parser —
+    // LocalUsageEstimator reuses it rather than carrying a duplicate.
+    private static let isoFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    private static let isoPlain: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+    static func parseResetDate(_ s: String) -> Date? {
+        if let d = isoFractional.date(from: s) { return d }
+        return isoPlain.date(from: s)
+    }
+
+    // MARK: - helpers
+
+    private static func jsonWindow(_ any: Any?) -> WindowUsage? {
+        guard let dict = any as? [String: Any],
+              let util = (dict["utilization"] as? NSNumber)?.doubleValue else { return nil }
+        let resets = (dict["resets_at"] as? String).flatMap(parseResetDate)
+        return WindowUsage(utilization: clamp(util), resetsAt: resets)
+    }
+
+    private static func headerWindow(_ lower: [String: String], utilKey: String, resetKey: String) -> WindowUsage? {
+        guard let utilStr = lower[utilKey], let util = Double(utilStr) else { return nil }
+        let resets = lower[resetKey].flatMap { Double($0) }.map { Date(timeIntervalSince1970: $0) }
+        return WindowUsage(utilization: clamp(util * 100), resetsAt: resets)
+    }
+
+    private static func normalize(_ headers: [AnyHashable: Any]) -> [String: String] {
+        var out: [String: String] = [:]
+        for (k, v) in headers {
+            guard let key = k as? String else { continue }
+            out[key.lowercased()] = "\(v)"
+        }
+        return out
+    }
+
+    private static func clamp(_ v: Double) -> Double { min(100, max(0, v)) }
+}

--- a/Sources/UsageStore.swift
+++ b/Sources/UsageStore.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+enum UsageEndpoints {
+    // Force-unwrap is provably safe: these are compile-time-constant valid URLs.
+    static let usage = URL(string: "https://api.anthropic.com/api/oauth/usage")!
+    static let messages = URL(string: "https://api.anthropic.com/v1/messages")!
+    static let beta = "oauth-2025-04-20"
+    static let anthropicVersion = "2023-06-01"
+    static let userAgent = "claude-code/2.1.5"
+}
+
+final class UsageStore {
+    private(set) var snapshot: UsageSnapshot?
+
+    private let cacheURL: URL
+    private let home: URL
+    private let configDir: URL?
+    private let session: URLSession
+    private let now: () -> Date
+    var minRefresh: TimeInterval // network floor; follows the user's refresh interval (main-thread only)
+
+    private var lastFetch: Date = .distantPast
+    private var inFlight = false
+
+    init(cacheURL: URL,
+         home: URL,
+         configDir: URL?,
+         session: URLSession = .shared,
+         now: @escaping () -> Date = { Date() },
+         minRefresh: TimeInterval = 300) {
+        self.cacheURL = cacheURL
+        self.home = home
+        self.configDir = configDir
+        self.session = session
+        self.now = now
+        self.minRefresh = minRefresh
+        self.snapshot = UsageStore.loadCache(cacheURL)
+    }
+
+    // Honor `$CLAUDE_CONFIG_DIR`; else the standard ~/.claude location.
+    private func claudeDir() -> URL { configDir ?? home.appendingPathComponent(".claude") }
+    private func projectsDir() -> URL { claudeDir().appendingPathComponent("projects") }
+}
+
+extension UsageStore {
+    // The network floor must sit BELOW the timer interval. `lastFetch` is stamped when a fetch
+    // COMPLETES — a couple seconds after the tick that started it — so a tick exactly one interval
+    // later lands a hair under a floor==interval and gets skipped, halving the real refresh rate
+    // (a 2-min setting became ~4 min). A 30s margin clears that gap; force refreshes ignore it.
+    static func floor(forIntervalMinutes minutes: Int) -> TimeInterval {
+        max(30, TimeInterval(max(1, minutes) * 60 - 30))
+    }
+
+    static func shouldFetch(force: Bool, lastFetch: Date, now: Date, minRefresh: TimeInterval) -> Bool {
+        if force { return true }
+        return now.timeIntervalSince(lastFetch) >= minRefresh
+    }
+}
+
+extension UsageStore {
+    // Must be invoked on the main thread.
+    func refresh(force: Bool, completion: @escaping (UsageSnapshot) -> Void) {
+        // Floor only short-circuits when we have something to return.
+        if let cached = snapshot,
+           !UsageStore.shouldFetch(force: force, lastFetch: lastFetch, now: now(), minRefresh: minRefresh) {
+            DispatchQueue.main.async { completion(cached) }
+            return
+        }
+        if inFlight {
+            let snap = snapshot ?? placeholder()
+            DispatchQueue.main.async { completion(snap) }
+            return
+        }
+        inFlight = true
+
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let self else { return }
+            let token = CredentialResolver.resolve(
+                env: ProcessInfo.processInfo.environment,
+                home: self.home,
+                configDir: self.configDir,
+                runSecurity: { SecurityKeychain.readToken(timeout: 8) }
+            )
+
+            guard let token else {
+                // No token at all -> honest local totals, clearly a non-percentage source.
+                let est = LocalUsageEstimator.estimate(projectsDir: self.projectsDir(), now: self.now())
+                let snap = UsageSnapshot(session: nil, week: nil,
+                                         localTokensToday: est.today, localTokensWeek: est.week,
+                                         source: .signedOut, lastUpdated: self.now())
+                self.complete(snap, persist: true, completion: completion)
+                return
+            }
+
+            if token.isExpired(now: self.now()) {
+                // We do not refresh the token ourselves in v1 -> "Re-login" state.
+                let snap = UsageSnapshot(session: nil, week: nil,
+                                         localTokensToday: nil, localTokensWeek: nil,
+                                         source: .expired, lastUpdated: self.now())
+                self.complete(snap, persist: false, completion: completion) // don't overwrite the on-disk last-good cache
+                return
+            }
+
+            self.getUsage(token: token, completion: completion)
+        }
+    }
+
+    // No cached snapshot yet (first launch, or the in-flight/error fallbacks) -> a minimal
+    // signed-out shell so the widget still has something non-blank to show.
+    private func placeholder() -> UsageSnapshot {
+        UsageSnapshot(session: nil, week: nil, localTokensToday: nil, localTokensWeek: nil,
+                      source: .signedOut, lastUpdated: now())
+    }
+}
+
+extension UsageStore {
+    private func getUsage(token: OAuthToken, completion: @escaping (UsageSnapshot) -> Void) {
+        var req = URLRequest(url: UsageEndpoints.usage)
+        req.httpMethod = "GET"
+        req.setValue("Bearer \(token.accessToken)", forHTTPHeaderField: "Authorization")
+        req.setValue(UsageEndpoints.beta, forHTTPHeaderField: "anthropic-beta")
+        req.setValue(UsageEndpoints.userAgent, forHTTPHeaderField: "User-Agent")
+
+        session.dataTask(with: req) { [weak self] data, response, _ in
+            guard let self else { return }
+            let code = (response as? HTTPURLResponse)?.statusCode ?? 0
+            if code == 200, let data, let snap = UsageParser.parseUsageJSON(data, now: self.now()) {
+                self.complete(snap, persist: true, completion: completion)
+                return
+            }
+            // Endpoint disabled / unauthorized / rate-limited -> Messages-headers fallback.
+            if [401, 404, 410, 429].contains(code) {
+                self.postMessages(token: token, completion: completion)
+                return
+            }
+            self.finishFallback(completion: completion) // transient error -> keep last-good
+        }.resume()
+    }
+
+    private func postMessages(token: OAuthToken, completion: @escaping (UsageSnapshot) -> Void) {
+        var req = URLRequest(url: UsageEndpoints.messages)
+        req.httpMethod = "POST"
+        req.setValue("Bearer \(token.accessToken)", forHTTPHeaderField: "Authorization")
+        req.setValue(UsageEndpoints.beta, forHTTPHeaderField: "anthropic-beta")
+        req.setValue(UsageEndpoints.anthropicVersion, forHTTPHeaderField: "anthropic-version") // required
+        req.setValue(UsageEndpoints.userAgent, forHTTPHeaderField: "User-Agent")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: Any] = [
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 1,
+            "messages": [["role": "user", "content": "hi"]]
+        ]
+        req.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        session.dataTask(with: req) { [weak self] _, response, _ in
+            guard let self else { return }
+            if let http = response as? HTTPURLResponse,
+               let snap = UsageParser.parseRateLimitHeaders(http.allHeaderFields, now: self.now()) {
+                self.complete(snap, persist: true, completion: completion)
+                return
+            }
+            self.finishFallback(completion: completion)
+        }.resume()
+    }
+
+    // Off-main: persist only touches the immutable cacheURL + the passed-in value, so disk IO here
+    // is safe; all mutable-state writes are deferred to the main thread.
+    private func complete(_ snap: UsageSnapshot, persist: Bool, completion: @escaping (UsageSnapshot) -> Void) {
+        if persist { UsageStore.saveCache(snap, to: cacheURL) }
+        DispatchQueue.main.async {
+            self.snapshot = snap
+            self.lastFetch = self.now() // any network attempt counts toward the 5-min floor
+            self.inFlight = false
+            completion(snap)
+        }
+    }
+
+    // Never blank: reuse last-good, else a minimal signed-out shell. Hops to main FIRST so the
+    // `snapshot` read happens on the same thread that writes it (no cross-thread access).
+    private func finishFallback(completion: @escaping (UsageSnapshot) -> Void) {
+        DispatchQueue.main.async {
+            let snap = self.snapshot ?? self.placeholder()
+            self.lastFetch = self.now() // a failed attempt still counts toward the 5-min floor
+            self.inFlight = false
+            completion(snap)
+        }
+    }
+}
+
+extension UsageStore {
+    private struct CachedWindow: Codable { var utilization: Double; var resetsAt: Date? }
+    private struct CachedSnapshot: Codable {
+        var session: CachedWindow?
+        var week: CachedWindow?
+        var localTokensToday: Int?
+        var localTokensWeek: Int?
+        var source: String
+        var lastUpdated: Date
+    }
+
+    static func saveCache(_ snap: UsageSnapshot, to url: URL) {
+        let dto = CachedSnapshot(
+            session: snap.session.map { CachedWindow(utilization: $0.utilization, resetsAt: $0.resetsAt) },
+            week: snap.week.map { CachedWindow(utilization: $0.utilization, resetsAt: $0.resetsAt) },
+            localTokensToday: snap.localTokensToday,
+            localTokensWeek: snap.localTokensWeek,
+            source: snap.source.rawValue,
+            lastUpdated: snap.lastUpdated
+        )
+        guard let data = try? JSONEncoder().encode(dto) else { return }
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        try? data.write(to: url)
+    }
+
+    static func loadCache(_ url: URL) -> UsageSnapshot? {
+        guard let data = try? Data(contentsOf: url),
+              let dto = try? JSONDecoder().decode(CachedSnapshot.self, from: data) else { return nil }
+        return UsageSnapshot(
+            session: dto.session.map { WindowUsage(utilization: $0.utilization, resetsAt: $0.resetsAt) },
+            week: dto.week.map { WindowUsage(utilization: $0.utilization, resetsAt: $0.resetsAt) },
+            localTokensToday: dto.localTokensToday,
+            localTokensWeek: dto.localTokensWeek,
+            source: UsageSource(rawValue: dto.source) ?? .signedOut, // unknown/newer string -> safe default, keeps the rest of the snapshot
+            lastUpdated: dto.lastUpdated
+        )
+    }
+}

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -173,6 +173,12 @@ final class StatusController: NSObject, NSMenuDelegate {
     var spinAngle: CGFloat = 0
     var frameIdx = 0
 
+    // Usage widget, merged into this single status item.
+    let store: UsageStore
+    var usageTimer: Timer?                  // periodic usage refresh
+    var menuTimer: Timer?                   // live reset-countdown while the menu is open
+    var barViews: [ProgressBarView] = []    // open rows, marked dirty live by menuTimer
+
     let launchedAt = Date()
     var notNeededSince: Date?
     let launchGrace: TimeInterval = 5   // settle time after launch before we may quit
@@ -213,6 +219,9 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     let brand = NSColor(srgbRed: 0.851, green: 0.467, blue: 0.341, alpha: 1) // #d97757, Anthropic's official "Orange" accent
     let amber = NSColor(srgbRed: 0.95, green: 0.73, blue: 0.18, alpha: 1) // "awaiting permission" yellow dot
+    // Shared so the title text, the percent element, and the inline bar/dot offset (computed from
+    // this font's capHeight) stay in lockstep — a size/weight tweak can't drift them apart.
+    static let menuBarFont = NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular)
     let frames: [NSImage] = StatusController.loadFrames()
     let spriteFPS: Double = 9 // tune: 8 frames per loop -> ~0.9s/cycle
 
@@ -254,7 +263,8 @@ final class StatusController: NSObject, NSMenuDelegate {
         }
     }
 
-    override init() {
+    init(store: UsageStore) {
+        self.store = store
         super.init()
         let d = UserDefaults.standard
         if d.object(forKey: "showTimer") != nil { showTimer = d.bool(forKey: "showTimer") }
@@ -269,6 +279,13 @@ final class StatusController: NSObject, NSMenuDelegate {
         RunLoop.main.add(t, forMode: .common)
         pollTimer = t
         tick()
+
+        // Usage: arm the periodic refresh and kick a first fetch so the indicator paints ASAP.
+        startUsageTimer()
+        store.refresh(force: false) { [weak self] _ in
+            self?.evaluate() // re-render the glyph/title with the fresh utilization
+        }
+
         ensureHooksInstalled()
         checkForUpdate()
     }
@@ -379,11 +396,19 @@ final class StatusController: NSObject, NSMenuDelegate {
         let t = Timer(timeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in self?.spinTick() }
         RunLoop.main.add(t, forMode: .common)  // .common so it fires during menu tracking
         spinTimer = t
+        // Live reset-countdown on the usage rows: a slower .common-mode timer marks them dirty.
+        menuTimer?.invalidate()
+        let mt = Timer(timeInterval: 30, repeats: true) { [weak self] _ in
+            self?.barViews.forEach { $0.tick() }
+        }
+        RunLoop.main.add(mt, forMode: .common)
+        menuTimer = mt
     }
     func menuDidClose(_ menu: NSMenu) {
         menuIsOpen = false
         sessionMenuItems.removeAll()
         spinTimer?.invalidate(); spinTimer = nil
+        menuTimer?.invalidate(); menuTimer = nil
     }
 
     // Advance the spinner and repaint only the working-state rows' leading icons.
@@ -412,26 +437,102 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     func menuNeedsUpdate(_ menu: NSMenu) {
         menu.removeAllItems()
+        barViews.removeAll()
         checkForUpdate() // refreshes the update cache for next open (gated to once a day)
 
-        sessionMenuItems.removeAll()
-        if !sessions.isEmpty {
-            menu.addItem(header("Sessions"))
-            for s in sessions.values.sorted(by: { $0.ts > $1.ts }) {
-                let now = Date().timeIntervalSince1970
-                let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
-                let view = SessionRowView(id: s.id, width: CGFloat(uiConfig()["boxWidth"] ?? 300))
-                let sid = s.id, ep = s.entrypoint, tp = s.termProgram
-                view.onClick = { [weak self] in menu.cancelTracking(); self?.openSession(sid, entrypoint: ep, termProgram: tp) }
-                configureSessionRow(view, s, eff: eff)
-                let it = NSMenuItem()
-                it.view = view
-                menu.addItem(it)
-                sessionMenuItems.append((it, s.id))  // kept so tick() can live-update the timers
-            }
-            menu.addItem(.separator())
+        // Stats (unlabeled): the usage bars, or the known sign-in / expired states.
+        let snap = store.snapshot
+        switch snap?.source {
+        case .signedOut?:
+            menu.addItem(infoRow("Sign in to Claude Code"))
+            addLocalRows(menu, snap) // honest local totals alongside the sign-in prompt
+        case .expired?:
+            menu.addItem(infoRow("Re-login to Claude Code"))
+        default:
+            addBarRow(menu, title: "Session (5h)", window: snap?.session)
+            addBarRow(menu, title: "Weekly (7d)", window: snap?.week)
         }
 
+        // Sessions (unlabeled): no divider above — a blank spacer widens the gap from the bars.
+        sessionMenuItems.removeAll()
+        if !sessions.isEmpty { menu.addItem(spacerRow(12)) }
+        for s in sessions.values.sorted(by: { $0.ts > $1.ts }) {
+            let now = Date().timeIntervalSince1970
+            let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
+            let view = SessionRowView(id: s.id, width: CGFloat(uiConfig()["boxWidth"] ?? 300))
+            let sid = s.id, ep = s.entrypoint, tp = s.termProgram
+            view.onClick = { [weak self] in menu.cancelTracking(); self?.openSession(sid, entrypoint: ep, termProgram: tp) }
+            configureSessionRow(view, s, eff: eff)
+            let it = NSMenuItem()
+            it.view = view
+            menu.addItem(it)
+            sessionMenuItems.append((it, s.id))  // kept so tick() can live-update the timers
+        }
+
+        menu.addItem(spacerRow(12)) // same breathing room before the divider as above the sessions
+        menu.addItem(.separator())
+
+        menu.addItem(NSMenuItem(title: "Version \(currentVersion)", action: nil, keyEquivalent: ""))
+        if let latest = UserDefaults.standard.string(forKey: "latestVersion"), versionIsNewer(latest, than: currentVersion) {
+            let up = NSMenuItem(title: "Update available", action: #selector(openLatestRelease), keyEquivalent: "")
+            up.target = self
+            menu.addItem(up)
+        }
+
+        // Everything configurable lives one level down to keep the top level slim.
+        let settingsItem = NSMenuItem(title: "Settings", action: nil, keyEquivalent: "")
+        settingsItem.submenu = buildSettingsMenu(snap: snap)
+        menu.addItem(settingsItem)
+
+        let q = NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q")
+        q.target = self
+        menu.addItem(q)
+    }
+
+    // The grouped + labeled settings, in a "Settings ▸" submenu off the slim top-level menu.
+    func buildSettingsMenu(snap: UsageSnapshot?) -> NSMenu {
+        let menu = NSMenu()
+
+        // Stats: usage-meter settings + a manual refresh (badge shows the last-updated time).
+        menu.addItem(header("Stats"))
+
+        menu.addItem(MenuBuilders.choiceSubmenu(
+            title: "Usage window",
+            choices: [("Session", UsageScope.session.rawValue),
+                      ("Weekly", UsageScope.week.rawValue), ("Most urgent", UsageScope.urgent.rawValue)],
+            selected: AppSettings.shared.usageWindow.rawValue,
+            action: #selector(chooseUsageWindow(_:)), target: self))
+
+        menu.addItem(MenuBuilders.choiceSubmenu(
+            title: "Usage display",
+            choices: [("Inline bar", UsageDisplay.bar.rawValue),
+                      ("Dot", UsageDisplay.dot.rawValue), ("Percentage", UsageDisplay.percent.rawValue),
+                      ("Off", UsageDisplay.off.rawValue)],
+            selected: AppSettings.shared.usageDisplay.rawValue,
+            action: #selector(chooseUsageDisplay(_:)), target: self))
+
+        // A monochrome dot carries no severity info, so omit Monochrome while the dot display is active.
+        var colorChoices: [(label: String, key: String)] = [
+            ("Claude", ColorTheme.claude.rawValue), ("System", ColorTheme.system.rawValue)]
+        if AppSettings.shared.usageDisplay != .dot {
+            colorChoices.insert(("Monochrome", ColorTheme.mono.rawValue), at: 0)
+        }
+        menu.addItem(MenuBuilders.choiceSubmenu(
+            title: "Usage colors",
+            choices: colorChoices,
+            selected: AppSettings.shared.statusColorTheme.rawValue,
+            action: #selector(chooseColors(_:)), target: self))
+
+        menu.addItem(MenuBuilders.choiceSubmenu(
+            title: "Refresh interval",
+            choices: [("2 min", "2"), ("5 min", "5"), ("10 min", "10")],
+            selected: String(AppSettings.shared.refreshIntervalMinutes),
+            action: #selector(AppSettings.chooseRefreshInterval(_:)), target: AppSettings.shared))
+
+        menu.addItem(refreshRow(snap)) // manual fetch; the badge shows the last-updated time
+        menu.addItem(.separator())
+
+        // Options: activity-icon appearance + app behavior.
         menu.addItem(header("Options"))
 
         menu.addItem(toggleRow(title: "Show timer", isOn: showTimer) { [weak self] on in
@@ -443,10 +544,13 @@ final class StatusController: NSObject, NSMenuDelegate {
             self?.playCompletionSound = on
             UserDefaults.standard.set(on, forKey: "completionSound")
         })
+        // The setter persists + reconciles via onChange; LoginItem flips the OS login item here.
+        menu.addItem(toggleRow(title: "Launch at login", isOn: AppSettings.shared.launchAtLogin) { on in
+            AppSettings.shared.launchAtLogin = on
+            LoginItem.setEnabled(on)
+        })
 
-        menu.addItem(.separator())
-
-        let animParent = NSMenuItem(title: "Animation Style", action: nil, keyEquivalent: "")
+        let animParent = NSMenuItem(title: "Icon animation", action: nil, keyEquivalent: "")
         let animSub = NSMenu()
         for (style, name) in [(AnimStyle.web, "Claude Spark"), (AnimStyle.code, "Claude Code"), (AnimStyle.crab, "Crab Walking")] {
             let it = NSMenuItem(title: name, action: #selector(chooseStyle(_:)), keyEquivalent: "")
@@ -458,7 +562,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         animParent.submenu = animSub
         menu.addItem(animParent)
 
-        let colorParent = NSMenuItem(title: "Color theme", action: nil, keyEquivalent: "")
+        let colorParent = NSMenuItem(title: "Icon color", action: nil, keyEquivalent: "")
         let colorSub = NSMenu()
         for (sys, name) in [(false, "Orange"), (true, "System")] {
             let it = NSMenuItem(title: name, action: #selector(chooseColor(_:)), keyEquivalent: "")
@@ -483,21 +587,20 @@ final class StatusController: NSObject, NSMenuDelegate {
         hideParent.submenu = hideSub
         menu.addItem(hideParent)
 
-        menu.addItem(.separator())
-        menu.addItem(NSMenuItem(title: "Version \(currentVersion)", action: nil, keyEquivalent: ""))
-        if let latest = UserDefaults.standard.string(forKey: "latestVersion"), versionIsNewer(latest, than: currentVersion) {
-            let up = NSMenuItem(title: "Update available", action: #selector(openLatestRelease), keyEquivalent: "")
-            up.target = self
-            menu.addItem(up)
-        }
-        let q = NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q")
-        q.target = self
-        menu.addItem(q)
+        return menu
     }
 
     func header(_ title: String) -> NSMenuItem {
         if #available(macOS 14.0, *) { return NSMenuItem.sectionHeader(title: title) }
         let it = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        it.isEnabled = false
+        return it
+    }
+
+    // A blank, non-selectable row of a fixed height — a visual gap between groups without a divider line.
+    func spacerRow(_ height: CGFloat) -> NSMenuItem {
+        let it = NSMenuItem()
+        it.view = NSView(frame: NSRect(x: 0, y: 0, width: 1, height: height))
         it.isEnabled = false
         return it
     }
@@ -888,6 +991,9 @@ final class StatusController: NSObject, NSMenuDelegate {
     // Stay while Claude desktop is open OR a session is active; otherwise quit after a
     // short debounced grace (warmup-session churn must not kill us).
     func checkLifecycle() {
+        // Launch-at-login keeps us resident across sessions (so the usage meter stays visible);
+        // a login-launched process must not self-quit.
+        if AppSettings.shared.launchAtLogin { return }
         let now = Date()
         if now.timeIntervalSince(launchedAt) < launchGrace { return }
         if claudeDesktopRunning() || sessionCount() > 0 {
@@ -899,17 +1005,6 @@ final class StatusController: NSObject, NSMenuDelegate {
         } else {
             notNeededSince = now
         }
-    }
-
-    // Read the last non-empty line of a (possibly large) file by tailing ~8KB.
-    func lastLine(ofFileAt path: String) -> String? {
-        guard let fh = FileHandle(forReadingAtPath: path) else { return nil }
-        defer { try? fh.close() }
-        let size = (try? fh.seekToEnd()) ?? 0
-        let chunk: UInt64 = 8192
-        try? fh.seek(toOffset: size > chunk ? size - chunk : 0)
-        guard let data = try? fh.readToEnd(), let s = String(data: data, encoding: .utf8) else { return nil }
-        return s.split(separator: "\n").last { !$0.isEmpty }.map(String.init)
     }
 
     // Last actual turn line (a user/assistant message), ignoring the bookkeeping lines Claude Code
@@ -963,19 +1058,226 @@ final class StatusController: NSObject, NSMenuDelegate {
         if showTimer, startedAt > 0 {
             text += "  " + elapsed(max(0, Int(Date().timeIntervalSince1970 - startedAt)))
         }
-        if text.isEmpty {
+
+        // Base text run: labelColor adapts (white on dark bar, black on light); monospaced
+        // digits keep the elapsed clock from nudging neighboring menu bar icons.
+        let attrs: [NSAttributedString.Key: Any] = [
+            .foregroundColor: NSColor.labelColor,
+            .font: Self.menuBarFont,
+        ]
+        let title = NSMutableAttributedString()
+        if !text.isEmpty { title.append(NSAttributedString(string: " \(text)", attributes: attrs)) }
+
+        // Inline usage element (bar/dot/percent) is always appended AFTER the activity text. It
+        // shows even when idle (empty base text) so usage is visible without an active turn.
+        if let element = usageTitleElement() { title.append(element) }
+
+        if title.length == 0 { // neither activity text nor a usage element -> icon only
             button.imagePosition = .imageOnly
             button.attributedTitle = NSAttributedString(string: "")
             return
         }
         button.imagePosition = .imageLeading
-        // labelColor adapts: white on a dark menu bar, black on a light one. Monospaced
-        // digits keep the elapsed clock from nudging neighboring menu bar icons.
-        let attrs: [NSAttributedString.Key: Any] = [
-            .foregroundColor: NSColor.labelColor,
-            .font: NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular),
-        ]
-        button.attributedTitle = NSAttributedString(string: " \(text)", attributes: attrs)
+        button.attributedTitle = title
+    }
+
+    // MARK: usage refresh + menu rows
+
+    // Single dispatcher for AppSettings.onChange: re-arm the usage timer for a possibly-changed
+    // interval (and its network floor), then re-render.
+    func settingsChanged() {
+        store.minRefresh = UsageStore.floor(forIntervalMinutes: AppSettings.shared.refreshIntervalMinutes)
+        startUsageTimer()
+        evaluate()
+    }
+
+    func startUsageTimer() {
+        usageTimer?.invalidate()
+        let minutes = max(1, AppSettings.shared.refreshIntervalMinutes)
+        let t = Timer(timeInterval: TimeInterval(minutes * 60), repeats: true) { [weak self] _ in self?.usageTick() }
+        RunLoop.main.add(t, forMode: .common) // survive menu tracking, like the activity poll timer
+        usageTimer = t
+    }
+
+    func usageTick() {
+        store.refresh(force: false) { [weak self] _ in // store enforces the network floor
+            self?.evaluate()
+        }
+    }
+
+    @objc func refreshNow() {
+        store.refresh(force: true) { [weak self] _ in // bypasses the network floor
+            self?.evaluate()
+        }
+    }
+
+    func addBarRow(_ menu: NSMenu, title: String, window: WindowUsage?) {
+        // A nil window means the API didn't report this scope (the parser accepts a snapshot with
+        // only one window present) — show it as unknown rather than a misleading "0%".
+        guard let window else {
+            menu.addItem(infoRow("\(title) — no data"))
+            return
+        }
+        let util = window.utilization
+        // Threshold the rounded value so the bar's severity color can't disagree with the "%"
+        // label at a boundary (e.g. 79.6 renders "80%" but is still .warn on the raw value).
+        let color = UsageColors.color(level: UsageStatus.level(util.rounded()), theme: AppSettings.shared.statusColorTheme)
+        let view = ProgressBarView(title: title, utilization: util, resetsAt: window.resetsAt,
+                                   color: color)
+        let item = NSMenuItem()
+        item.view = view
+        menu.addItem(item)
+        barViews.append(view)
+    }
+
+    func addLocalRows(_ menu: NSMenu, _ snap: UsageSnapshot?) {
+        if let today = snap?.localTokensToday { menu.addItem(infoRow("Today ≈ \(formatted(today)) tokens")) }
+        if let week = snap?.localTokensWeek { menu.addItem(infoRow("This week ≈ \(formatted(week)) tokens")) }
+    }
+
+    func infoRow(_ title: String) -> NSMenuItem {
+        let it = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        it.isEnabled = false // display rows, not actions; no selection highlight
+        return it
+    }
+
+    func formatted(_ n: Int) -> String {
+        let f = NumberFormatter(); f.numberStyle = .decimal
+        return f.string(from: NSNumber(value: n)) ?? "\(n)"
+    }
+
+    func stalenessHint(_ lastUpdated: Date) -> String {
+        let mins = Int(Date().timeIntervalSince(lastUpdated) / 60)
+        if mins < 1 { return "Updated just now" }
+        if mins < 60 { return "Updated \(mins)m ago" }
+        return "Updated \(mins / 60)h ago"
+    }
+
+    // "Refresh" with the last-updated time as a native right-aligned badge (macOS 14+) so it
+    // aligns with the system's own right-edge elements. Clicking refreshes now.
+    func refreshRow(_ snap: UsageSnapshot?) -> NSMenuItem {
+        let item = NSMenuItem(title: "Refresh", action: #selector(refreshNow), keyEquivalent: "")
+        item.target = self
+        guard let snap else { return item }
+        let time = stalenessHint(snap.lastUpdated).replacingOccurrences(of: "Updated ", with: "") // "2m ago"/"just now"
+        if #available(macOS 14.0, *) {
+            item.badge = NSMenuItemBadge(string: time)
+        } else {
+            item.title = "Refresh  (\(time))"
+        }
+        return item
+    }
+
+    // The usage choosers write a setter, which fires onChange -> settingsChanged() -> re-render.
+    @objc func chooseUsageWindow(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String, let w = UsageScope(rawValue: key) else { return }
+        AppSettings.shared.usageWindow = w
+    }
+
+    @objc func chooseUsageDisplay(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String, let m = UsageDisplay(rawValue: key) else { return }
+        // A dot can't be monochrome (no severity info), so promote a stale mono theme to Claude.
+        if m == .dot, AppSettings.shared.statusColorTheme == .mono {
+            AppSettings.shared.statusColorTheme = .claude
+        }
+        AppSettings.shared.usageDisplay = m
+    }
+
+    @objc func chooseColors(_ sender: NSMenuItem) {
+        guard let key = sender.representedObject as? String, let t = ColorTheme(rawValue: key) else { return }
+        AppSettings.shared.statusColorTheme = t
+    }
+
+    // MARK: usage indicator (shared image + title rendering)
+
+    // The utilization the indicator reflects, per the user's chosen window. Single source for the
+    // bar/dot/percent title element. Returns nil when there's no snapshot or window data.
+    func currentUtilization() -> Double? {
+        guard let snap = store.snapshot else { return nil }
+        switch AppSettings.shared.usageWindow {
+        case .session: return snap.session?.utilization
+        case .week:    return snap.week?.utilization
+        case .urgent:  // whichever present window is higher
+            switch (snap.session, snap.week) {
+            case let (s?, w?): return max(s.utilization, w.utilization)
+            case let (s?, nil): return s.utilization
+            case let (nil, w?): return w.utilization
+            default: return nil
+            }
+        }
+    }
+
+    // Threshold color for the current theme (nil == monochrome -> caller uses labelColor/template).
+    func usageThemeColor(_ util: Double) -> NSColor? {
+        UsageColors.color(level: UsageStatus.level(util), theme: AppSettings.shared.statusColorTheme)
+    }
+
+    // The bar/dot/percent element appended after the activity text. nil when no utilization is available.
+    func usageTitleElement() -> NSAttributedString? {
+        let display = AppSettings.shared.usageDisplay
+        guard display != .off, let util = currentUtilization() else { return nil } // .off hides the widget
+        let themeColor = usageThemeColor(util) // nil == mono -> template image / labelColor text
+        switch display {
+        case .off:
+            return nil // unreachable (guarded above); keeps the switch exhaustive
+        case .percent:
+            let shown = util.rounded() // color the displayed (rounded) value so number and severity agree at boundaries
+            let attrs: [NSAttributedString.Key: Any] = [
+                .foregroundColor: usageThemeColor(shown) ?? NSColor.labelColor, // theme severity color; adaptive labelColor in mono
+                .font: Self.menuBarFont,
+            ]
+            return NSAttributedString(string: "  \(Int(shown))%", attributes: attrs)
+        case .bar:
+            return attachmentString(miniBarImage(util, color: themeColor))
+        case .dot:
+            // A nil (mono) color draws an info-less template dot; fall back to a colored Claude dot.
+            let dotColor = themeColor ?? UsageColors.color(level: UsageStatus.level(util), theme: .claude)
+            return attachmentString(miniDotImage(color: dotColor))
+        }
+    }
+
+    // ~24x8 inline progress bar (track + fill). nil color => template (mono/adaptive).
+    func miniBarImage(_ util: Double, color: NSColor?) -> NSImage {
+        let w: CGFloat = 24, h: CGFloat = 8
+        let c = color ?? NSColor.labelColor
+        let img = NSImage(size: NSSize(width: w, height: h), flipped: false) { _ in
+            let track = NSRect(x: 0, y: 1, width: w, height: h - 2)
+            c.withAlphaComponent(0.25).setFill()
+            NSBezierPath(roundedRect: track, xRadius: 2, yRadius: 2).fill()
+            let fillW = CGFloat(max(0, min(1, util / 100))) * w
+            if fillW > 0 {
+                c.setFill()
+                NSBezierPath(roundedRect: NSRect(x: 0, y: 1, width: fillW, height: h - 2), xRadius: 2, yRadius: 2).fill()
+            }
+            return true
+        }
+        img.isTemplate = (color == nil)
+        return img
+    }
+
+    // ~8x8 filled circle. nil color => template (mono/adaptive).
+    func miniDotImage(color: NSColor?) -> NSImage {
+        let s: CGFloat = 8
+        let img = NSImage(size: NSSize(width: s, height: s), flipped: false) { _ in
+            (color ?? NSColor.labelColor).setFill()
+            NSBezierPath(ovalIn: NSRect(x: 0, y: 0, width: s, height: s)).fill()
+            return true
+        }
+        img.isTemplate = (color == nil)
+        return img
+    }
+
+    // Wrap a small image as a text attachment, vertically centered on the cap height, with a
+    // leading gap from the text.
+    func attachmentString(_ image: NSImage) -> NSAttributedString {
+        let attachment = NSTextAttachment()
+        attachment.image = image
+        let font = Self.menuBarFont
+        let yOffset = (font.capHeight - image.size.height) / 2
+        attachment.bounds = NSRect(x: 0, y: yOffset, width: image.size.width, height: image.size.height)
+        let result = NSMutableAttributedString(string: "  ")
+        result.append(NSAttributedString(attachment: attachment))
+        return result
     }
 
     // MARK: icon
@@ -1108,5 +1410,25 @@ final class StatusController: NSObject, NSMenuDelegate {
 
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory)
-let controller = StatusController()
+
+// Hidden self-test mode: pure-logic checks over the single AppKit binary (no XCTest).
+// Runs before StatusController() so self-tests never spawn status items or install hooks.
+if CommandLine.arguments.contains("--selftest") { exit(runSelfTests() ? 0 : 1) }
+
+let settings = AppSettings.shared
+let home = FileManager.default.homeDirectoryForCurrentUser
+let cacheURL = home.appendingPathComponent(".claude/statusbar/usage-cache.json")
+let configDir = ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"].map { URL(fileURLWithPath: $0) }
+// The network floor sits just below the user's refresh interval, so a scheduled tick isn't dropped.
+let store = UsageStore(cacheURL: cacheURL, home: home, configDir: configDir,
+                       minRefresh: UsageStore.floor(forIntervalMinutes: settings.refreshIntervalMinutes))
+
+// One merged status item showing the activity glyph + usage indicator.
+let controller = StatusController(store: store)
+
+// Any global setting change re-reads prefs, re-arms the usage timer, and re-renders.
+settings.onChange = { controller.settingsChanged() }
+
+LoginItem.setEnabled(settings.launchAtLogin) // reconcile the OS login item with the stored pref
+
 app.run()

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ TEAM_ID="W9JZ4932LA"
 NOTARY_PROFILE="${NOTARY_PROFILE:-claude-statusbar}"
 
 SIGN_ID="$(security find-identity -v -p codesigning 2>/dev/null \
-  | grep "Developer ID Application" | grep "$TEAM_ID" | head -1 | sed -E 's/.*"(.*)"/\1/')"
+  | grep "Developer ID Application" | grep "$TEAM_ID" | head -1 | sed -E 's/.*"(.*)"/\1/' || true)"
 
 # Strip extended attributes (Finder info, quarantine, etc.) that bundled resources can
 # carry — codesign rejects them ("resource fork, Finder information, ... not allowed").


### PR DESCRIPTION
- Add a usage meter: resolve the OAuth token (env/file/Keychain), read /api/oauth/usage (0-100) with a /v1/messages rate-limit-header fallback, cache to disk, and estimate local tokens from ~/.claude/projects when signed out
- Render usage inline in the menu bar as a bar, dot, or percentage — or Off to hide it — colored by a Claude/System/Mono severity theme
- Slim the dropdown: usage bars and live sessions at the top (no section labels, a gap between them), then Version / Settings / Quit
- Move all configuration into a Settings submenu, grouped and labeled: Stats (usage window/display/colors, refresh interval, manual Refresh) and Options (timer, completion sound, launch at login, icon animation, icon color, hide idle)
- Add launch-at-login (SMAppService) so the meter stays resident across sessions
- Harden refresh/cache: the network floor sits below the refresh interval, ISO-8601 parsing falls back across formats, errors keep the last-good snapshot
- Cover the usage logic with --selftest checks (status thresholds, parser, credentials, local estimate, cache round-trip)