### PR TITLE
feat: add LLM-powered smart session titles with Smart/Folder modes

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -183,7 +183,7 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     // One parsed entry per live session file (state.d/<id>.json), refreshed each tick.
     struct Session {
-        var id: String, state: String, label: String, project: String, transcript: String
+        var id: String, state: String, label: String, project: String, dirName: String, transcript: String
         var entrypoint: String  // CLAUDE_CODE_ENTRYPOINT: "cli", "claude-desktop", …
         var termProgram: String // TERM_PROGRAM for CLI sessions: "Apple_Terminal", "iTerm.app", …
         var startedAt: Double, ts: Double
@@ -194,6 +194,7 @@ final class StatusController: NSObject, NSMenuDelegate {
             self.state = o["state"] as? String ?? "idle"
             self.label = o["label"] as? String ?? ""
             self.project = o["project"] as? String ?? ""
+            self.dirName = o["dirName"] as? String ?? ""
             self.transcript = o["transcript"] as? String ?? ""
             self.entrypoint = o["entrypoint"] as? String ?? ""
             self.termProgram = o["term_program"] as? String ?? ""
@@ -221,6 +222,7 @@ final class StatusController: NSObject, NSMenuDelegate {
     var showTimer = false
     var iconSystem = false // false = brand Orange; true = adaptive black/white (template image)
     var playCompletionSound = false // chime when a turn longer than ~1 min finishes
+    var titleMode = "llm"           // "llm" = smart titles; "folder" = raw directory names
     lazy var completionSound: NSSound? = {
         guard let p = Bundle.main.path(forResource: "completion", ofType: "mp3"),
               let s = NSSound(contentsOfFile: p, byReference: true) else { return nil }
@@ -261,6 +263,11 @@ final class StatusController: NSObject, NSMenuDelegate {
         if d.object(forKey: "iconSystem") != nil { iconSystem = d.bool(forKey: "iconSystem") }
         if d.object(forKey: "completionSound") != nil { playCompletionSound = d.bool(forKey: "completionSound") }
         if let s = d.string(forKey: "animStyle"), let st = AnimStyle(rawValue: s) { animStyle = st }
+        // Load titleMode from shared prefs.json (also read/written by the Node hook scripts).
+        let prefsPath = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/statusbar/prefs.json")
+        if let prefsData = try? Data(contentsOf: URL(fileURLWithPath: prefsPath)),
+           let prefsObj = try? JSONSerialization.jsonObject(with: prefsData) as? [String: Any],
+           let mode = prefsObj["titleMode"] as? String { titleMode = mode }
         let menu = NSMenu()
         menu.delegate = self
         statusItem.menu = menu
@@ -483,6 +490,18 @@ final class StatusController: NSObject, NSMenuDelegate {
         hideParent.submenu = hideSub
         menu.addItem(hideParent)
 
+        let titleModeParent = NSMenuItem(title: "Session title", action: nil, keyEquivalent: "")
+        let titleModeSub = NSMenu()
+        for (mode, name) in [("llm", "Smart"), ("folder", "Folder")] {
+            let it = NSMenuItem(title: name, action: #selector(chooseTitleMode(_:)), keyEquivalent: "")
+            it.target = self
+            it.representedObject = mode
+            it.state = titleMode == mode ? .on : .off
+            titleModeSub.addItem(it)
+        }
+        titleModeParent.submenu = titleModeSub
+        menu.addItem(titleModeParent)
+
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Version \(currentVersion)", action: nil, keyEquivalent: ""))
         if let latest = UserDefaults.standard.string(forKey: "latestVersion"), versionIsNewer(latest, than: currentVersion) {
@@ -580,9 +599,12 @@ final class StatusController: NSObject, NSMenuDelegate {
         }
     }
 
-    // Just the repo/cwd; the surface (CLI/APP) renders as a trailing badge instead of inline.
+    // Respects titleMode: "llm" → LLM title, "folder" → directory name.
     func sessionName(_ s: Session) -> String {
-        s.project.isEmpty ? "session" : s.project
+        switch titleMode {
+        case "folder":  return s.dirName.isEmpty ? s.project : s.dirName
+        default:        return s.project.isEmpty ? "session" : s.project
+        }
     }
 
     // CLAUDE_CODE_ENTRYPOINT -> a short all-caps badge tag.
@@ -770,6 +792,29 @@ final class StatusController: NSObject, NSMenuDelegate {
         animTimer?.invalidate(); animTimer = nil // recreate at the new style's fps
         frameIdx = 0
         evaluate()
+    }
+
+    @objc func chooseTitleMode(_ sender: NSMenuItem) {
+        guard let mode = sender.representedObject as? String else { return }
+        titleMode = mode
+        writePrefs()
+        // Update already-visible session rows so the change takes effect immediately
+        // without requiring a menu close/reopen.
+        for (item, id) in sessionMenuItems {
+            guard let s = sessions[id], let v = item.view as? SessionRowView else { continue }
+            configureSessionRow(v, s, eff: s.eff)
+        }
+    }
+
+    // Persist titleMode to the shared prefs.json file that the Node hook scripts also read.
+    func writePrefs() {
+        let prefsPath = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/statusbar/prefs.json")
+        let obj: [String: Any] = ["titleMode": titleMode]
+        if let data = try? JSONSerialization.data(withJSONObject: obj, options: .prettyPrinted) {
+            let dir = (prefsPath as NSString).deletingLastPathComponent
+            try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            try? data.write(to: URL(fileURLWithPath: prefsPath), options: .atomic)
+        }
     }
 
     // MARK: state polling

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Installs the status-bar hooks into ~/.claude/settings.json (merging, never
-// clobbering existing hooks) and copies update.js to ~/.claude/statusbar/.
+// clobbering existing hooks) and copies hook scripts to ~/.claude/statusbar/.
 // Re-runnable: existing status-bar hooks are stripped before re-adding.
 
 const fs = require("fs");
@@ -13,6 +13,8 @@ const sbDir = path.join(home, ".claude", "statusbar");
 const MARKER = sbDir; // every hook command we add points inside this dir
 const updateDest = path.join(sbDir, "update.js");
 const lifecycleDest = path.join(sbDir, "lifecycle.js");
+const titleDest = path.join(sbDir, "title.js");
+const retitleDest = path.join(sbDir, "retitle.js");
 const settingsPath = path.join(home, ".claude", "settings.json");
 const node = process.execPath;
 
@@ -29,6 +31,9 @@ fs.rmSync(path.join(sbDir, "state.json"), { force: true });
 fs.rmSync(path.join(sbDir, "sessions.d"), { recursive: true, force: true });
 fs.copyFileSync(path.join(__dirname, "update.js"), updateDest);
 fs.copyFileSync(path.join(__dirname, "lifecycle.js"), lifecycleDest);
+// Copy title generation scripts if present (future-proof: harmless if missing).
+try { fs.copyFileSync(path.join(__dirname, "title.js"), titleDest); } catch {}
+try { fs.copyFileSync(path.join(__dirname, "retitle.js"), retitleDest); } catch {}
 
 const cmd = (evt) => `${node} ${updateDest} ${evt}`;
 const life = (evt) => `${node} ${lifecycleDest} ${evt}`;
@@ -71,5 +76,5 @@ addUnmatched("SessionEnd", life("end"));
 
 fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
 console.log("Installed status-bar hooks into", settingsPath);
-console.log("Scripts:", updateDest, "and", lifecycleDest);
+console.log("Scripts:", updateDest, lifecycleDest, titleDest, retitleDest);
 console.log("Backup (first run only):", settingsPath + ".bak-statusbar");

--- a/hooks/lifecycle.js
+++ b/hooks/lifecycle.js
@@ -14,6 +14,7 @@ const EXEC = "ClaudeStatusBar";
 const dir = path.join(os.homedir(), ".claude", "statusbar");
 const stateDir = path.join(dir, "state.d");
 const event = process.argv[2];
+const node = process.execPath;
 
 fs.mkdirSync(stateDir, { recursive: true });
 
@@ -30,7 +31,7 @@ let input = "", done = false;
 process.stdin.on("data", (d) => (input += d));
 process.stdin.on("end", () => run());
 process.stdin.on("error", () => run());
-setTimeout(run, 1000); // hooks always pipe stdin, but never hang the session
+setTimeout(run, 1000);
 
 function run() {
   if (done) return; done = true;
@@ -40,18 +41,14 @@ function run() {
   const statePath = path.join(stateDir, id + ".json");
 
   if (event === "start") {
-    // If the app isn't running, any leftover session files are stale (e.g. a prior
-    // crash) — clear them so the count starts honest.
     if (!running()) { try { for (const f of fs.readdirSync(stateDir)) fs.rmSync(path.join(stateDir, f), { force: true }); } catch {} }
-    // Seed an idle file: counts the session immediately, and clears any frozen state from a
-    // resume (SessionStart fires on resume with no active turn). Replaces the old clearStaleState.
     try {
-      writeAtomic(statePath, { state: "idle", label: "", tool: "", project: cwd ? path.basename(cwd) : "", sessionId: id, transcript: "", entrypoint: process.env.CLAUDE_CODE_ENTRYPOINT || "", term_program: process.env.TERM_PROGRAM || "", startedAt: 0, ts: Math.floor(Date.now() / 1000) });
+      writeAtomic(statePath, { state: "idle", label: "", tool: "", project: cwd ? path.basename(cwd) : "", dirName: cwd ? path.basename(cwd) : "", sessionId: id, transcript: "", entrypoint: process.env.CLAUDE_CODE_ENTRYPOINT || "", term_program: process.env.TERM_PROGRAM || "", startedAt: 0, ts: Math.floor(Date.now() / 1000) });
     } catch {}
     cp.spawn("open", ["-g", "-b", BUNDLE_ID], { stdio: "ignore", detached: true }).unref();
+    // Fire-and-forget: generate an LLM title for the session in the background.
+    if (cwd) cp.spawn(node, [path.join(dir, "title.js"), id, cwd], { stdio: "ignore", detached: true, env: process.env }).unref();
   } else if (event === "end") {
-    // Removing the file drops this session from the aggregate — this is also what recovers a
-    // frozen animation on force-quit (SessionEnd fires, but no Stop). No state rewrite needed.
     try { fs.rmSync(statePath, { force: true }); } catch {}
   }
   process.exit(0);

--- a/hooks/retitle.js
+++ b/hooks/retitle.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Conversation-based title generator. Called by update.js after a placeholder ("新对话" / "New Chat")
+// session accumulates 3+ user turns. Reads the transcript to understand what
+// the conversation is about, then asks the LLM for a short title.
+// Usage: node retitle.js <session_id> <transcript_path>
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const [,, sessionId, transcriptPath] = process.argv;
+if (!sessionId || !transcriptPath) process.exit(1);
+
+const dir = path.join(os.homedir(), ".claude", "statusbar");
+const stateDir = path.join(dir, "state.d");
+const sid = String(sessionId).replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64);
+const titleFile = path.join(stateDir, sid + ".title");
+const statePath = path.join(stateDir, sid + ".json");
+
+// Debounce: skip if the title was updated less than 30 seconds ago.
+try {
+  const st = fs.statSync(titleFile);
+  if ((Date.now() - st.mtimeMs) < 30_000) process.exit(0);
+} catch {}
+
+// ── Extract recent user messages from transcript ────────────────────
+// Claude Code transcript uses: {"type":"user", "message":{"role":"user","content":"..."}}
+// Tool results also have type=user/role=user but content is [{"type":"tool_result",...}] — skip those.
+function extractMessages(transcriptPath) {
+  const messages = [];
+  try {
+    const raw = fs.readFileSync(transcriptPath, "utf8");
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const obj = JSON.parse(line);
+        if (obj.type !== "user") continue;
+        const msg = obj.message || {};
+        if (msg.role !== "user") continue;
+        const content = msg.content;
+        // Real user prompts are plain strings. Tool results are arrays
+        // whose first block is {"type":"tool_result",...} — skip those.
+        if (typeof content === "string" && content.length > 0) {
+          messages.push(content);
+        } else if (Array.isArray(content)) {
+          // Only count if the first block is a user text, not a tool_result.
+          if (content.length > 0 && content[0].type !== "tool_result") {
+            const text = content.map(b => (b && b.text) ? b.text : "").join(" ").trim();
+            if (text) messages.push(text);
+          }
+        }
+      } catch {}
+    }
+  } catch {}
+  return messages;
+}
+
+const allMessages = extractMessages(transcriptPath);
+if (allMessages.length === 0) process.exit(1);
+
+// Last 5 user messages, each capped at 200 chars for the prompt.
+const recent = allMessages.slice(-5).map(m => m.slice(0, 200));
+
+const prompt = [
+  "Below are the user's most recent messages in this Claude Code session.",
+  "Generate a SHORT title (4-12 characters) summarizing what this session is about.",
+  "Rules: prefer Chinese if the conversation is in Chinese; no quotes, no punctuation;",
+  'no abbreviations like "I18n", "a11y", "cfg"; no code-style concatenations with + or -;',
+  'no filler words like "session" or "chat"; output ONLY the title, max 12 characters.',
+  "",
+  "Recent messages:",
+  ...recent.map((m, i) => `${i + 1}. ${m}`),
+].join("\n");
+
+// ── Call LLM ─────────────────────────────────────────────────────────
+const baseUrl = (process.env.ANTHROPIC_BASE_URL || "https://api.anthropic.com").replace(/\/$/, "");
+const apiKey = process.env.ANTHROPIC_AUTH_TOKEN || "";
+const model = process.env.ANTHROPIC_MODEL || "claude-sonnet-4-6";
+
+fetch(baseUrl + "/v1/messages", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": apiKey,
+    "anthropic-version": "2023-06-01",
+  },
+  body: JSON.stringify({
+    model,
+    max_tokens: 60,
+    messages: [{ role: "user", content: prompt }],
+    thinking: { type: "disabled" },
+  }),
+})
+  .then(r => {
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return r.json();
+  })
+  .then(data => {
+    const blocks = data.content || [];
+    const textBlock = blocks.find(b => b.type === "text") || blocks[0] || {};
+    const raw = (textBlock.text || textBlock.thinking || "").replace(/["'\n]/g, "").trim();
+    const title = raw.slice(0, 12);
+    if (!title || title === "新对话" || title === "New Chat") process.exit(1); // retry-worthy failure
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(titleFile, title);
+    // Patch the state file so the app reflects the title immediately.
+    try {
+      const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+      state.project = title;
+      const tmp = statePath + ".retitle." + process.pid + ".tmp";
+      fs.writeFileSync(tmp, JSON.stringify(state));
+      fs.renameSync(tmp, statePath);
+    } catch {}
+    process.exit(0);
+  })
+  .catch(() => process.exit(1));

--- a/hooks/title.js
+++ b/hooks/title.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// LLM-powered session title generator. Called from lifecycle.js on SessionStart.
+// Reads project context from cwd, asks the LLM for a 2-4 word title, caches it.
+// When no project descriptor files exist, writes a placeholder ("新对话"/"New Chat");
+// retitle.js will generate a real title later from conversation content.
+// Usage: node title.js <session_id> <cwd>
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const [,, sessionId, cwd] = process.argv;
+if (!sessionId || !cwd) process.exit(1);
+
+const dir = path.join(os.homedir(), ".claude", "statusbar");
+const stateDir = path.join(dir, "state.d");
+const sid = String(sessionId).replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64);
+const titleFile = path.join(stateDir, sid + ".title");
+const statePath = path.join(stateDir, sid + ".json");
+
+// Already generated for this session — don't waste an API call.
+if (fs.existsSync(titleFile)) process.exit(0);
+
+// ── Gather project context ──────────────────────────────────────────
+const DESCRIPTOR_FILES = [
+  "CLAUDE.md", "README.md", "README.org", "readme.md",
+  "package.json", "Cargo.toml", "go.mod", "pyproject.toml",
+  "Gemfile", "Makefile", "docker-compose.yml", "Dockerfile",
+];
+
+function gatherContext(cwd) {
+  const files = [];
+  for (const name of DESCRIPTOR_FILES) {
+    try {
+      const raw = fs.readFileSync(path.join(cwd, name), "utf8");
+      files.push({ name, preview: raw.slice(0, 400) });
+    } catch {}
+  }
+  return files;
+}
+
+const context = gatherContext(cwd);
+const dirBasename = path.basename(cwd);
+
+// Placeholder label: locale-aware so non-Chinese users see "New Chat".
+const NEW_CHAT = (process.env.LANG || process.env.LC_ALL || "").startsWith("zh") ? "新对话" : "New Chat";
+
+// ── Function to update state file atomically ─────────────────────────
+function patchState(projectTitle) {
+  try {
+    const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    state.project = projectTitle;
+    state.dirName = dirBasename;
+    const tmp = statePath + ".title." + process.pid + ".tmp";
+    fs.writeFileSync(tmp, JSON.stringify(state));
+    fs.renameSync(tmp, statePath);
+  } catch {}
+}
+
+// No descriptor files found — label with placeholder; retitle.js handles the rest.
+if (context.length === 0) {
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(titleFile, NEW_CHAT);
+  patchState(NEW_CHAT);
+  process.exit(0);
+}
+
+const prompt = [
+  `The working directory is named "${dirBasename}".`,
+  "Below are previews of key files found in this directory:",
+  ...context.map(f => `--- ${f.name} ---\n${f.preview}`),
+  "",
+  'Give this coding/AI session a VERY SHORT descriptive title.',
+  'Rules: 2-4 words; prefer Chinese if the project content is in Chinese; no quotes, no punctuation, no "Project" or "Session" filler.',
+  "Output ONLY the title, nothing else.",
+].join("\n");
+
+// ── Call LLM ─────────────────────────────────────────────────────────
+const baseUrl = (process.env.ANTHROPIC_BASE_URL || "https://api.anthropic.com").replace(/\/$/, "");
+const apiKey = process.env.ANTHROPIC_AUTH_TOKEN || "";
+const model = process.env.ANTHROPIC_MODEL || "claude-sonnet-4-6";
+
+fetch(baseUrl + "/v1/messages", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": apiKey,
+    "anthropic-version": "2023-06-01",
+  },
+  body: JSON.stringify({
+    model,
+    max_tokens: 60,
+    messages: [{ role: "user", content: prompt }],
+    thinking: { type: "disabled" },
+  }),
+})
+  .then(r => {
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return r.json();
+  })
+  .then(data => {
+    const blocks = data.content || [];
+    const textBlock = blocks.find(b => b.type === "text") || blocks[0] || {};
+    const raw = (textBlock.text || textBlock.thinking || "").replace(/["'\n]/g, "").trim();
+    const title = raw.slice(0, 30) || dirBasename;
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(titleFile, title);
+    patchState(title);
+    process.exit(0);
+  })
+  .catch(() => process.exit(1));

--- a/hooks/update.js
+++ b/hooks/update.js
@@ -8,9 +8,11 @@
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const cp = require("child_process");
 
 const dir = path.join(os.homedir(), ".claude", "statusbar");
 const stateDir = path.join(dir, "state.d");
+const prefsPath = path.join(dir, "prefs.json");
 const event = process.argv[2] || "";
 
 const TOOL_LABELS = {
@@ -22,13 +24,30 @@ const TOOL_LABELS = {
 
 const safeId = (s) => String(s || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64) || "unknown";
 
+// Read titleMode preference. Defaults to "llm" if the file doesn't exist.
+function readTitleMode() {
+  try { const p = JSON.parse(fs.readFileSync(prefsPath, "utf8")); return p.titleMode || "llm"; } catch { return "llm"; }
+}
+
+// Spawn retitle.js in background to generate a title from conversation content.
+function spawnRetitle(sid, transcriptPath) {
+  if (!transcriptPath) return;
+  const node = process.execPath;
+  const script = path.join(dir, "retitle.js");
+  if (!fs.existsSync(script)) return;
+  cp.spawn(node, [script, sid, transcriptPath], {
+    stdio: "ignore",
+    detached: true,
+    env: process.env,
+  }).unref();
+}
+
 let raw = "";
 process.stdin.on("data", (d) => (raw += d));
 process.stdin.on("end", () => {
   let p = {};
   try { p = JSON.parse(raw || "{}"); } catch {}
 
-  // Off by default; CLAUDE_STATUSBAR_DEBUG=1 logs every hook invocation to hooks.log.
   if (process.env.CLAUDE_STATUSBAR_DEBUG === "1") {
     try {
       fs.mkdirSync(dir, { recursive: true });
@@ -37,17 +56,23 @@ process.stdin.on("end", () => {
     } catch {}
   }
 
-  // This session's own file is the unit of state AND the liveness marker. Writing it on any
-  // event also tracks sessions that predate the hook install (never fired SessionStart).
   const sid = safeId(p.session_id);
   const statePath = path.join(stateDir, sid + ".json");
 
-  // Read THIS session's prior state (not a shared global) so startedAt/transcript carry over
-  // within the session and never bleed across concurrent sessions.
   let prev = {};
   try { prev = JSON.parse(fs.readFileSync(statePath, "utf8")); } catch {}
 
-  const project = p.cwd ? path.basename(p.cwd) : prev.project || "";
+  // ── Project / title resolution ───────────────────────────────────
+  let project = "";
+  const titleMode = readTitleMode();
+  if (titleMode === "folder") {
+    project = p.cwd ? path.basename(p.cwd) : prev.project || "";
+  } else {
+    const titleFile = path.join(stateDir, sid + ".title");
+    try { project = fs.readFileSync(titleFile, "utf8").trim(); } catch {}
+    project = project || (p.cwd ? path.basename(p.cwd) : prev.project || "");
+  }
+
   const ts = Math.floor(Date.now() / 1000);
   let state = "idle", label = "", startedAt = prev.startedAt || 0;
 
@@ -56,8 +81,6 @@ process.stdin.on("end", () => {
       state = "thinking"; label = "Thinking…"; startedAt = ts; break;
     case "pre": {
       const t = p.tool_name || "";
-      // Known tools get a friendly verb; everything else (incl. long mcp__server__method
-      // names) collapses to a generic "Using tool".
       state = "tool"; label = TOOL_LABELS[t] || "Using tool";
       if (!startedAt) startedAt = ts;
       break;
@@ -67,9 +90,6 @@ process.stdin.on("end", () => {
       if (!startedAt) startedAt = ts;
       break;
     case "notify": {
-      // Only a permission prompt drives the icon here (CLI path; desktop uses permreq). Ignore
-      // every other Notification (esp. the idle_prompt "Claude is waiting for your input") so the
-      // icon rests instead of parking on a confusing "Waiting for you". See CLAUDE.md.
       const m = (p.message || "").toLowerCase();
       const isPerm = p.notification_type === "permission_prompt" ||
         m.includes("permission") || m.includes("approve") || m.includes("allow");
@@ -78,7 +98,6 @@ process.stdin.on("end", () => {
       break;
     }
     case "permreq":
-      // Desktop-app permission signal; not redundant with notify (that's CLI-only). See CLAUDE.md.
       state = "permission"; label = "Awaiting permission"; startedAt = 0; break;
     case "stop":
       state = "done"; label = "Done"; startedAt = 0; break;
@@ -86,17 +105,22 @@ process.stdin.on("end", () => {
       return;
   }
 
-  // CLAUDE_CODE_ENTRYPOINT tags the surface running this session ("cli", "claude-desktop", …);
-  // carried over from prev for the odd event where the env var isn't set.
   const entrypoint = process.env.CLAUDE_CODE_ENTRYPOINT || prev.entrypoint || "";
-  // TERM_PROGRAM identifies the terminal app for a CLI session (Apple_Terminal, iTerm.app,
-  // vscode, WezTerm, …); the app uses it to bring that terminal to the front on a row click.
   const termProgram = process.env.TERM_PROGRAM || prev.term_program || "";
-  const out = { state, label, tool: p.tool_name || "", project, sessionId: p.session_id || "", transcript: p.transcript_path || prev.transcript || "", entrypoint, term_program: termProgram, startedAt, ts };
+  const transcript = p.transcript_path || prev.transcript || "";
+  // dirName is the raw folder basename — always stored so the app can switch
+  // between "Smart" / "Folder" modes in real time without re-running hooks.
+  const dirName = p.cwd ? path.basename(p.cwd) : prev.dirName || project;
+  const out = { state, label, tool: p.tool_name || "", project, dirName, sessionId: p.session_id || "", transcript, entrypoint, term_program: termProgram, startedAt, ts };
   try {
     fs.mkdirSync(stateDir, { recursive: true });
     const tmp = statePath + "." + process.pid + ".tmp";
     fs.writeFileSync(tmp, JSON.stringify(out));
     fs.renameSync(tmp, statePath);
   } catch {}
+
+  // ── Per-message retitle: spawn on every prompt ──────────────────
+  if (event === "prompt" && titleMode === "llm") {
+    spawnRetitle(sid, transcript);
+  }
 });


### PR DESCRIPTION
- Add Session title submenu (Smart/Folder) with real-time switching
- Smart mode: auto-generate short titles via LLM from project context and conversation content
- Folder mode: display raw directory names (original behavior)
- title.js: generates initial title from project descriptor files on SessionStart
- retitle.js: regenerates title from conversation content on every user message (30s debounce)
- Works with any Anthropic-compatible API via ANTHROPIC_BASE_URL/ANTHROPIC_AUTH_TOKEN/ANTHROPIC_MODEL env vars
- Falls back to locale-aware placeholder (新对话/New Chat) when context is insufficient