### PR TITLE
feat: add "Show status text" menu bar toggle

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -254,6 +254,7 @@ final class StatusController: NSObject, NSMenuDelegate {
     enum AnimStyle: String { case web, code, crab }
     var animStyle: AnimStyle = .web
     var showTimer = false
+    var showStatusText = true // show the "Thinking…"/"Running Code"/etc. label; off = icon (+ timer) only
     var iconSystem = false // false = brand Orange; true = adaptive black/white (template image)
     var playCompletionSound = false // chime when a turn longer than ~5 min finishes
     var useThinkingWords = true     // rotate a playful verb ("Manifesting…") in place of "Thinking…"
@@ -322,6 +323,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         super.init()
         let d = UserDefaults.standard
         if d.object(forKey: "showTimer") != nil { showTimer = d.bool(forKey: "showTimer") }
+        if d.object(forKey: "showStatusText") != nil { showStatusText = d.bool(forKey: "showStatusText") }
         if d.object(forKey: "iconSystem") != nil { iconSystem = d.bool(forKey: "iconSystem") }
         if d.object(forKey: "completionSound") != nil { playCompletionSound = d.bool(forKey: "completionSound") }
         if d.object(forKey: "thinkingWords") != nil { useThinkingWords = d.bool(forKey: "thinkingWords") }
@@ -525,6 +527,11 @@ final class StatusController: NSObject, NSMenuDelegate {
         menu.addItem(toggleRow(title: "Show timer", isOn: showTimer) { [weak self] on in
             self?.showTimer = on
             UserDefaults.standard.set(on, forKey: "showTimer")
+            self?.applyTitle()
+        })
+        menu.addItem(toggleRow(title: "Show status text", isOn: showStatusText) { [weak self] on in
+            self?.showStatusText = on
+            UserDefaults.standard.set(on, forKey: "showStatusText")
             self?.applyTitle()
         })
         menu.addItem(toggleRow(title: "Completion sound", qualifier: "5min+", isOn: playCompletionSound) { [weak self] on in
@@ -1077,9 +1084,10 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     func applyTitle() {
         guard let button = statusItem.button else { return }
-        var text = activeBase
+        var text = showStatusText ? activeBase : ""
         if showTimer, startedAt > 0 {
-            text += "  " + elapsed(max(0, Int(Date().timeIntervalSince1970 - startedAt)))
+            let clock = elapsed(max(0, Int(Date().timeIntervalSince1970 - startedAt)))
+            text = text.isEmpty ? clock : text + "  " + clock
         }
         if text.isEmpty {
             button.imagePosition = .imageOnly

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ TEAM_ID="W9JZ4932LA"
 NOTARY_PROFILE="${NOTARY_PROFILE:-claude-statusbar}"
 
 SIGN_ID="$(security find-identity -v -p codesigning 2>/dev/null \
-  | grep "Developer ID Application" | grep "$TEAM_ID" | head -1 | sed -E 's/.*"(.*)"/\1/')"
+  | grep "Developer ID Application" | grep "$TEAM_ID" | head -1 | sed -E 's/.*"(.*)"/\1/' || true)"
 
 # Strip extended attributes (Finder info, quarantine, etc.) that bundled resources can
 # carry — codesign rejects them ("resource fork, Finder information, ... not allowed").


### PR DESCRIPTION
## Summary
- Adds a "Show status text" toggle (on by default) next to "Show timer" in
  the menu bar dropdown. Turning it off hides the working label
  ("Thinking…", "Running Code", "Awaiting permission", …) to save menu bar
  space, so only the icon (and, if enabled, the elapsed timer) shows.
- Fixes build.sh: without a Developer ID cert installed, the SIGN_ID lookup
  pipeline failed under `set -eo pipefail` and silently aborted the whole
  build, even though the script is meant to fall back to an ad-hoc local
  build in that case.
