### PR TITLE
fix: recover the icon after Ctrl+C interrupts a reasoning turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Claude Status Bar are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Ctrl+C during the reasoning phase no longer leaves the icon stuck on a thinking word. Claude Code emits no hook or transcript signal for that interrupt, so the app now watches the transcript's modification time as a liveness clock: a live turn keeps flushing lines, an interrupted one goes silent. The icon rests within ~5 minutes of the interrupt (Esc still recovers immediately).
+
 ## [0.3.2] - 2026-07-02
 
 ### Added

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -962,13 +962,28 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     func renderResting() { render(label: "", color: iconColor, animate: false, startedAt: 0) }
 
-    // Per-session effective state with two recovery nets: an absolute age cap, plus the transcript
+    // Per-session effective state with two recovery nets: an absolute quiet cap, plus the transcript
     // "interrupted by user" marker (Esc / denied permission fire no hook, freezing the file). "done"
     // collapses to rest.
+    //
+    // Ctrl+C mid-reasoning fires no hook AND appends nothing to the transcript (unlike Esc, which
+    // writes the marker below), so the only tell is sustained silence on BOTH clocks: the last hook
+    // write (ts) and the transcript mtime. A live turn flushes a transcript line every time a content
+    // block completes (observed gaps < ~3 min), so 300s of total silence means the turn is dead. A
+    // rare longer block self-heals: this is recomputed every tick, so the next flush pops the session
+    // back to thinking with its original timer.
     func effectiveState(_ s: Session, now: Double) -> String {
         if s.state == "thinking" || s.state == "tool" || s.state == "permission" {
-            let cap: Double = s.state == "permission" ? 7200 : 900
-            if now - s.ts > cap { return "idle" }
+            let mtime = transcriptMTime(s)
+            // min(..., now) guards a future mtime (clock skew / network volume).
+            let quiet = now - min(max(s.ts, mtime ?? 0), now)
+            let cap: Double
+            switch s.state {
+            case "permission": cap = 7200 // waiting on the user legitimately writes nothing: never tighten
+            case "thinking": cap = mtime != nil ? 300 : 900 // no mtime signal -> keep the wide net
+            default: cap = 900 // "tool": a long build writes nothing until it ends
+            }
+            if quiet > cap { return "idle" }
             if !s.transcript.isEmpty, let last = lastTurnLine(ofFileAt: s.transcript),
                last.contains("interrupted by user") { return "idle" }
             return s.state
@@ -1043,6 +1058,16 @@ final class StatusController: NSObject, NSMenuDelegate {
         return s.split(separator: "\n").last {
             $0.contains("\"type\":\"user\"") || $0.contains("\"type\":\"assistant\"")
         }.map(String.init)
+    }
+
+    // Transcript mtime as a liveness clock: a live turn flushes a line every time a content block
+    // completes, an interrupted one never writes again. nil = no transcript / stat failed
+    // (pre-upgrade state file, deleted transcript) -> caller keeps the wide net.
+    func transcriptMTime(_ s: Session) -> Double? {
+        guard !s.transcript.isEmpty,
+              let attrs = try? FileManager.default.attributesOfItem(atPath: s.transcript),
+              let m = attrs[.modificationDate] as? Date else { return nil }
+        return m.timeIntervalSince1970
     }
 
     // MARK: render


### PR DESCRIPTION
## Problem

The known issue documented in the 0.3.2 changelog: pressing **Ctrl+C during the reasoning phase** in the terminal leaves the menu bar icon stuck on a thinking word (for up to 15 minutes, until the 900s cap). Claude Code fires no hook for that interrupt, and — unlike Esc, which writes the `interrupted by user` marker this app already checks — Ctrl+C appends nothing to the transcript. I verified against the current hook docs that none of the hook events (including the newer ones) fires on a user interrupt, so there is no signal for a hook to forward; the recovery has to live in the app's polling side.

## Fix

Use the transcript's **mtime as a second liveness clock**. A live reasoning turn flushes a transcript line every time a content block completes — measured gaps in real transcripts stay under ~3 minutes (worst observed: 176s). An interrupted turn never writes again. So `effectiveState` now demotes `thinking → idle` once **both** clocks — the last hook write (`ts`) and the transcript mtime — have been quiet for **300s** (~1.7× margin over the worst live gap).

Guardrails:

- **`permission` keeps its 7200s cap** — an unanswered permission prompt legitimately writes nothing; the mtime can only *extend* its window, never shrink it.
- **`tool` keeps the 900s cap** — a long build writes nothing until it ends, and Ctrl+C during a tool call already recovers instantly via the existing transcript marker.
- **Sessions with no readable transcript** (pre-upgrade state files, deleted transcripts) keep the old 900s wide net — never tighter without the signal.
- **False positives self-heal**: the state is recomputed every 0.4s tick from live data, so a rare >5-minute single reasoning block causes at most a transient resting icon that pops back (with its original timer) on the next transcript flush. A future mtime (clock skew, network volume) is clamped to now.
- The completion chime keys off the raw state, so an aborted turn never chimes.

No hook changes; hooks stay untouched. Cost is one extra `stat` per active session per tick, next to the 8KB tail read the app already does.

## Testing

Extracted the actual `Session` struct, `effectiveState`, `transcriptMTime`, and `lastTurnLine` from `main.swift` into a harness and ran 14 scenarios against real temp files with controlled mtimes — the Ctrl+C demotion plus every regression path (live reasoning with stale `ts`, permission longevity, long tools, Esc marker, missing/pre-upgrade transcripts, future mtime, `done` collapse). All pass. Manually verified end-to-end: Ctrl+C mid-reasoning → icon rests; next prompt resumes normally; Esc still recovers within one poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
