### PR TITLE
fix: enforce a single running instance of the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Claude Status Bar are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Only one instance of the app runs at a time. When a second copy exists on disk (an old copy in Downloads, a build next to the installed app), the session-start hook's launch-by-bundle-ID could start it alongside the running one, showing two menu bar icons. A new instance now quits immediately if one is already running, and a running instance quits older copies (which lack the guard) that launch after it.
+
 ## [0.3.2] - 2026-07-02
 
 ### Added

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1003,10 +1003,29 @@ final class StatusController: NSObject, NSMenuDelegate {
         return kill(pid, 0) == 0 || errno == EPERM
     }
 
+    // Evict twin instances that appear AFTER us — older builds have no launch guard, so the
+    // incumbent has to quit them. Polled from the tick because NSWorkspace's launch notifications
+    // are never posted for accessory (LSUIElement) apps like this one; the query is the same cost
+    // as the claudeDesktopRunning() enumeration the tick already does. The elder instance wins
+    // (launchDate, pid as tie-break), so two guarded copies can never evict each other.
+    func evictTwins() {
+        guard let bid = Bundle.main.bundleIdentifier else { return }
+        let me = NSRunningApplication.current
+        for other in NSRunningApplication.runningApplications(withBundleIdentifier: bid)
+        where other.processIdentifier != me.processIdentifier {
+            let mine = me.launchDate ?? .distantPast
+            let theirs = other.launchDate ?? .distantPast
+            if theirs > mine || (theirs == mine && other.processIdentifier > me.processIdentifier) {
+                other.terminate()   // polite quit; same-bundle-ID only, never another app
+            }
+        }
+    }
+
     // Stay while Claude desktop is open OR a session is active; otherwise quit after a
     // short debounced grace (warmup-session churn must not kill us).
     func checkLifecycle() {
         let now = Date()
+        evictTwins()
         if now.timeIntervalSince(launchedAt) < launchGrace { return }
         if claudeDesktopRunning() || sessionCount() > 0 {
             notNeededSince = nil
@@ -1224,5 +1243,16 @@ final class StatusController: NSObject, NSMenuDelegate {
 
 let app = NSApplication.shared
 app.setActivationPolicy(.accessory)
+
+// Single-instance guard. The SessionStart hook launches the app by bundle ID, and LaunchServices'
+// "already running" check is per app PATH — so a second copy on disk (a dev build next to the
+// /Applications release, a stray copy in Downloads, a mounted DMG) gets launched alongside the
+// running one and the menu bar shows two icons. If a twin is already running, defer to it.
+let myPID = ProcessInfo.processInfo.processIdentifier
+if let bid = Bundle.main.bundleIdentifier,
+   NSRunningApplication.runningApplications(withBundleIdentifier: bid)
+       .contains(where: { $0.processIdentifier != myPID }) {
+    exit(0)
+}
 let controller = StatusController()
 app.run()


### PR DESCRIPTION
## Problem

Run two Claude sessions while a second copy of the app exists anywhere on disk and you get **two identical menu bar icons**.

Why: the SessionStart hook launches the app with `open -g -b com.local.claudestatusbar`, and LaunchServices' "already running" check is per app **path**, not per bundle ID. It resolves the bundle ID to its registered canonical copy (usually `/Applications`), sees *that path* isn't running, and launches it — even though another copy (an old one in Downloads, a dev build, a copy run straight from the DMG) is already in the menu bar.

## Fix

A two-sided guard:

- **Newcomer defers** (bootstrap, before the status item is created): a starting instance that finds a running twin (same bundle ID, different pid) exits immediately — no icon ever appears.
- **Incumbent evicts** (from the existing lifecycle tick): the running instance politely `terminate()`s a twin that appears after it. This half matters because already-shipped builds have no launch guard — once one guarded version is running, it cleans up any older copy the hook launches.

The eviction is polled from the tick rather than observed because `NSWorkspace`'s launch notifications are **never posted for accessory (`LSUIElement`) apps** — I tried the observer first and it simply never fires for this app; the poll costs the same as the `claudeDesktopRunning()` enumeration the tick already does. The elder instance wins (launchDate, pid tie-break), so two guarded copies can never evict each other. Scoped strictly to the app's own bundle identifier; no other process is ever touched. No hook changes (gating the hook's `open` call would also have worked, but the app-side guard covers every launch path — login items, manual double-clicks — not just the hook).

## Testing

- Guarded incumbent + old unguarded 0.3.2 launched on top (the exact duplication scenario): the old copy quits within a second, one icon remains.
- Guarded copy launched while another guarded copy runs: the newcomer exits itself before creating its status item.
- Normal single-copy operation unaffected: launch, auto-launch via hook, and self-quit lifecycle behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
