### PR TITLE
feat: show running subagents as indented rows under their session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to Claude Status Bar are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Running subagents show under their session.** When Claude fans work out to subagents (the Task/Agent tool), each running one gets a small indented row under its session: a Claude Code-style status dot (grey while running, green when finished), the agent type ("Explore", "general-purpose", …), a snippet of the delegation prompt when Claude Code provides one, and its own elapsed timer. Subagents run in the background and often outlive the turn that spawned them — their rows stay for as long as they're actually working, and a session with live agents never counts as idle. A row whose agent finishes while the menu is open settles to a green dot, its timer hidden (menus can't drop rows mid-track); big fan-outs cap at 4 rows plus a "+ k more" line. Driven by Claude Code's SubagentStart/SubagentStop hooks — one tiny file per running agent, cleared at session boundaries and by the app's liveness reaping so crashes can't leave stale rows.
+
 ## [0.3.4] - 2026-07-09
 
 ### Added

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -246,6 +246,89 @@ final class SessionRowView: NSView {
     override func mouseDown(with event: NSEvent) { onClick?() }
 }
 
+// Indented mini-row under a session: [● dot] "agentType · task…"  <spacer>  timer.
+// One per RUNNING subagent. The dot follows Claude Code's own task-list styling: dim grey
+// while running, green once finished. Not clickable (no highlight/tracking): it's a status
+// readout, not a target — there is nowhere to jump for a subagent.
+final class AgentRowView: NSView {
+    let sessionId: String, agentId: String
+    private let iconView = NSImageView()     // the status dot
+    private let nameField = NSTextField(labelWithString: "")
+    private let timerField = NSTextField(labelWithString: "")
+    private let pad: CGFloat = 14, iconSize: CGFloat = 16
+    private let rowH: CGFloat
+    private var finished = false
+
+    init(sessionId: String, agentId: String, width: CGFloat, rowH: CGFloat, indent: CGFloat) {
+        self.sessionId = sessionId; self.agentId = agentId; self.rowH = rowH
+        super.init(frame: NSRect(x: 0, y: 0, width: width, height: rowH))
+        autoresizingMask = [.width]
+        let iconX = pad + indent
+        iconView.frame = NSRect(x: iconX, y: (rowH - iconSize) / 2, width: iconSize, height: iconSize)
+        iconView.imageScaling = .scaleNone   // the dot renders at its natural (small) size, centered
+        iconView.autoresizingMask = [.maxXMargin]
+        addSubview(iconView)
+        let font = NSFont.menuFont(ofSize: NSFont.menuFont(ofSize: 0).pointSize - 2)
+        nameField.font = font
+        nameField.lineBreakMode = .byTruncatingTail
+        nameField.frame = NSRect(x: iconX + iconSize + 6, y: (rowH - 16) / 2, width: 160, height: 16)
+        nameField.autoresizingMask = [.maxXMargin]
+        addSubview(nameField)
+        timerField.font = NSFont.monospacedSystemFont(ofSize: font.pointSize, weight: .regular)
+        timerField.textColor = .tertiaryLabelColor
+        timerField.alignment = .right
+        timerField.autoresizingMask = [.minXMargin]
+        addSubview(timerField)
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func configure(dot: NSImage?, agentType: String, task: String, timer: String, rightInset: CGFloat, timerGap: CGFloat) {
+        if finished { return }   // settled: green dot, dimmed text, no timer
+        iconView.image = dot
+        renderName(agentType: agentType, task: task)
+        timerField.stringValue = timer
+        let tfont = timerField.font ?? NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        let tw = ceil(timer.size(withAttributes: [.font: tfont]).width) + 2
+        // Same baseline alignment as the session row: the mono timer sits on the text's baseline.
+        let nf = nameField.font ?? NSFont.menuFont(ofSize: 0)
+        let baseline = { (f: NSFont) in (16 - (f.ascender - f.descender)) / 2 - f.descender }
+        let dy = baseline(nf) - baseline(tfont)
+        timerField.frame = NSRect(x: bounds.width - rightInset - tw, y: (rowH - 16) / 2 + dy, width: tw, height: 16)
+        nameField.frame.size.width = max(40, timerField.frame.minX - timerGap - nameField.frame.minX)
+    }
+    private func renderName(agentType: String, task: String) {
+        let para = NSMutableParagraphStyle()
+        para.lineBreakMode = .byTruncatingTail
+        para.allowsDefaultTighteningForTruncation = false  // constant tracking, honest ellipsis (see SessionRowView)
+        let font = nameField.font ?? NSFont.menuFont(ofSize: 0)
+        let text = NSMutableAttributedString(string: agentType, attributes: [
+            .font: font, .paragraphStyle: para,
+            .foregroundColor: finished ? NSColor.tertiaryLabelColor : .secondaryLabelColor,
+        ])
+        if !task.isEmpty {
+            text.append(NSAttributedString(string: " · " + task, attributes: [
+                .font: font, .paragraphStyle: para,
+                .foregroundColor: NSColor.tertiaryLabelColor,
+            ]))
+        }
+        nameField.attributedStringValue = text
+    }
+    // The agent finished while the menu is open. NSMenu can't remove items mid-track, so the row
+    // settles in place: green dot, dimmed text, timer hidden (elapsed time only means something
+    // while it's still climbing). The next menu open simply doesn't rebuild the row.
+    func markFinished(dot: NSImage?) {
+        guard !finished else { return }
+        finished = true
+        iconView.image = dot
+        timerField.isHidden = true
+        // Re-dim the type text (task text is already tertiary).
+        if let s = nameField.attributedStringValue.mutableCopy() as? NSMutableAttributedString {
+            s.addAttribute(.foregroundColor, value: NSColor.tertiaryLabelColor, range: NSRange(location: 0, length: s.length))
+            nameField.attributedStringValue = s
+        }
+    }
+}
+
 final class StatusController: NSObject, NSMenuDelegate {
     let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     let stateDir = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/statusbar/state.d")
@@ -292,12 +375,37 @@ final class StatusController: NSObject, NSMenuDelegate {
             self.ts = (o["ts"] as? NSNumber)?.doubleValue ?? 0
         }
     }
+    // One RUNNING subagent of a session (a file in <sid>.agents.d/, written by agents.js on
+    // SubagentStart, removed on SubagentStop).
+    struct AgentInfo {
+        var id: String          // agent_id (the filename)
+        var agentType: String   // "Explore", "general-purpose", custom names; "" if absent
+        var task: String        // one-line delegation prompt snippet (hook truncates to 200 chars)
+        var parentAgentId: String // "" unless nested; stored for future tree display, rendered flat
+        var startedAt: Double, ts: Double
+
+        init(json o: [String: Any], id: String) {
+            self.id = id
+            self.agentType = o["agentType"] as? String ?? ""
+            self.task = o["task"] as? String ?? ""
+            self.parentAgentId = o["parentAgentId"] as? String ?? ""
+            self.startedAt = (o["startedAt"] as? NSNumber)?.doubleValue ?? 0
+            self.ts = (o["ts"] as? NSNumber)?.doubleValue ?? 0
+        }
+    }
     var sessions: [String: Session] = [:]  // id -> latest parsed per-session state
     var fileMTimes: [String: Date] = [:]   // "<id>.json" -> last-parsed mtime (re-parse only on change)
+    // Kept OFF Session on purpose: reloadSessions() skips a session whose own file is unchanged,
+    // which is exactly the quiet stretch while a Task runs — agents stored on Session would go
+    // stale right when they matter. Parallel dicts keyed by session id sidestep that.
+    var sessionAgents: [String: [AgentInfo]] = [:]  // session id -> running agents, spawn order
+    var agentDirMTimes: [String: Date] = [:]        // session id -> agents.d mtime last parsed
     var gitHeadCache: [String: String] = [:]  // cwd -> resolved HEAD path ("" = confirmed non-git)
     var prevState: [String: String] = [:]  // id -> previous raw state per session
     var menuIsOpen = false                  // refresh the dropdown's per-session timers only while open
     var sessionMenuItems: [(item: NSMenuItem, id: String)] = []
+    var agentMenuItems: [(item: NSMenuItem, sessionId: String, agentId: String)] = []
+    var agentOverflowItems: [(item: NSMenuItem, sessionId: String)] = []
     var activeBase = ""        // label without the elapsed clock
     var startedAt: Double = 0  // unix seconds the current turn began (0 = no clock)
     var activeColor: NSColor? = nil
@@ -491,6 +599,8 @@ final class StatusController: NSObject, NSMenuDelegate {
     func menuDidClose(_ menu: NSMenu) {
         menuIsOpen = false
         sessionMenuItems.removeAll()
+        agentMenuItems.removeAll()
+        agentOverflowItems.removeAll()
     }
 
     // The session SET only changes on reopen (NSMenu can't add/remove rows reliably mid-track).
@@ -500,6 +610,24 @@ final class StatusController: NSObject, NSMenuDelegate {
             guard let s = sessions[id], let v = item.view as? SessionRowView else { continue }
             let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
             configureSessionRow(v, s, eff: eff)
+        }
+        // Agent rows: live rows tick their timers; a row whose agent finished (or whose whole turn
+        // ended) greys out in place — the set can't shrink mid-track, the next open drops it.
+        for (item, sid, aid) in agentMenuItems {
+            guard let v = item.view as? AgentRowView else { continue }
+            if let s = sessions[sid], let a = visibleAgents(for: s).first(where: { $0.id == aid }) {
+                configureAgentRow(v, a, now: now)
+            } else {
+                v.markFinished(dot: agentDot(done: true))
+            }
+        }
+        for (item, sid) in agentOverflowItems {
+            // The overflow line stays put; only its count can change (agents that finish while the
+            // menu is open shrink it, floored at the rows we can't remove).
+            guard let v = item.view?.subviews.first as? NSTextField else { continue }
+            let live = sessions[sid].map { visibleAgents(for: $0).count } ?? 0
+            let hidden = max(0, live - agentMenuItems.filter { $0.sessionId == sid }.count)
+            v.stringValue = hidden > 0 ? "+ \(hidden) more" : ""
         }
     }
 
@@ -515,6 +643,8 @@ final class StatusController: NSObject, NSMenuDelegate {
         }
 
         sessionMenuItems.removeAll()
+        agentMenuItems.removeAll()
+        agentOverflowItems.removeAll()
         let now = Date().timeIntervalSince1970
         // Gate ONLY the desktop app: opening/clicking a conversation there seeds an idle session without
         // real activity (the click-through clutter), so a desktop session stays out of the dropdown until
@@ -534,6 +664,9 @@ final class StatusController: NSObject, NSMenuDelegate {
         var visible = ordered.filter { s in
             let eff = s.eff.isEmpty ? effectiveState(s, now: now) : s.eff
             let resting = !(eff == "permission" || eff == "thinking" || eff == "tool")
+            // Background subagents keep working after the parent's turn ends, without bumping the
+            // session's ts — a session with live agents is active, not stale, so don't hide it.
+            if resting && !visibleAgents(for: s).isEmpty { return true }
             return !(stalePruneAge > 0 && resting && now - s.ts > stalePruneAge)
         }
         if visible.isEmpty, let lead = ordered.first { visible = [lead] }   // floor: never empty while alive
@@ -550,6 +683,30 @@ final class StatusController: NSObject, NSMenuDelegate {
                 it.view = view
                 menu.addItem(it)
                 sessionMenuItems.append((it, s.id))  // kept so tick() can live-update the timers
+
+                // Running subagents, indented under their session. Capped so a big fan-out can't
+                // swallow the menu; agents that START while the menu is open appear on next open
+                // (rows can't be added mid-track), which mirrors how session rows behave.
+                let agents = visibleAgents(for: s)
+                let cfg = uiConfig()
+                let cap = max(1, Int(cfg["agentRowsMax"] ?? 4))
+                for a in agents.prefix(cap) {
+                    let av = AgentRowView(sessionId: s.id, agentId: a.id,
+                                          width: CGFloat(cfg["boxWidth"] ?? 300),
+                                          rowH: CGFloat(cfg["agentRowH"] ?? 20),
+                                          indent: CGFloat(cfg["agentIndent"] ?? 18))
+                    configureAgentRow(av, a, now: now)
+                    let ai = NSMenuItem()
+                    ai.view = av
+                    menu.addItem(ai)
+                    agentMenuItems.append((ai, s.id, a.id))
+                }
+                if agents.count > cap {
+                    let oi = NSMenuItem()
+                    oi.view = agentOverflowView(count: agents.count - cap, cfg: cfg)
+                    menu.addItem(oi)
+                    agentOverflowItems.append((oi, s.id))
+                }
             }
             menu.addItem(.separator())
         } else if claudeDesktopRunning() {
@@ -701,6 +858,51 @@ final class StatusController: NSObject, NSMenuDelegate {
         if !s.branch.isEmpty { tip += " · " + s.branch }
         if !s.cwd.isEmpty { tip += "\n" + s.cwd }
         v.toolTip = tip
+    }
+
+    func configureAgentRow(_ v: AgentRowView, _ a: AgentInfo, now: Double) {
+        let cfg = uiConfig()
+        v.configure(dot: agentDot(done: false),
+                    agentType: a.agentType.isEmpty ? "agent" : a.agentType,
+                    task: truncated(a.task, max: 60, keep: 58),
+                    timer: elapsed(max(0, Int(now - a.startedAt))),
+                    rightInset: CGFloat(cfg["pillInset"] ?? 12),
+                    timerGap: CGFloat(cfg["timerGap"] ?? 10))
+        v.toolTip = a.task.isEmpty ? a.agentType : a.task   // the full (untruncated) delegation prompt
+    }
+
+    // Claude Code-style task dot: dim grey while an agent runs, green once it's done.
+    func agentDot(done: Bool) -> NSImage? {
+        guard let img = NSImage(systemSymbolName: "circle.fill", accessibilityDescription: nil) else { return nil }
+        let tint: NSColor = done ? .systemGreen : .tertiaryLabelColor
+        let size = CGFloat(uiConfig()["agentDotSize"] ?? 7)
+        return img.withSymbolConfiguration(
+            NSImage.SymbolConfiguration(pointSize: size, weight: .regular)
+                .applying(NSImage.SymbolConfiguration(paletteColors: [tint])))
+    }
+
+    // Dim "+ k more" line when a fan-out exceeds agentRowsMax; indented like the agent rows.
+    func agentOverflowView(count: Int, cfg: [String: Double]) -> NSView {
+        let tf = NSTextField(labelWithString: "+ \(count) more")
+        tf.font = NSFont.menuFont(ofSize: NSFont.menuFont(ofSize: 0).pointSize - 2)
+        tf.textColor = .tertiaryLabelColor
+        let indent = CGFloat(cfg["agentIndent"] ?? 18)
+        tf.frame = NSRect(x: 14 + indent + 16 + 6, y: 1, width: 160, height: 16)
+        let wrap = NSView(frame: NSRect(x: 0, y: 0, width: CGFloat(cfg["boxWidth"] ?? 300), height: 18))
+        wrap.autoresizingMask = [.width]
+        wrap.addSubview(tf)
+        return wrap
+    }
+
+    // Subagents run in the BACKGROUND: they outlive the parent's turn (Stop fires seconds after
+    // the spawn), so a row lives exactly as long as its file — SubagentStart to SubagentStop —
+    // regardless of what the parent is doing. The session's own liveness (pid reap) bounds them,
+    // plus an age cap as the belt for a crash that never fires SubagentStop: session restarts
+    // clear the dir, but a long-lived idle session shouldn't show a dead agent forever.
+    func visibleAgents(for s: Session) -> [AgentInfo] {
+        let cap = uiConfig()["agentMaxAge"] ?? 7200   // same order as the permission cap
+        let now = Date().timeIntervalSince1970
+        return (sessionAgents[s.id] ?? []).filter { now - $0.startedAt < cap }
     }
 
     func statusText(_ s: Session, eff: String) -> String {
@@ -883,6 +1085,7 @@ final class StatusController: NSObject, NSMenuDelegate {
     func tick() {
         checkLifecycle()
         reloadSessions()
+        reloadAgents()
         evaluate()
         if menuIsOpen { refreshOpenMenuRows() }
     }
@@ -917,6 +1120,47 @@ final class StatusController: NSObject, NSMenuDelegate {
             if gitHeadCache[s.cwd] == "" { gitHeadCache[s.cwd] = nil }
             s.branch = branchForCwd(s.cwd)   // only on file change (a hook event), never on a bare tick
             sessions[id] = s
+        }
+    }
+
+    func agentsDirPath(_ id: String) -> String {
+        (stateDir as NSString).appendingPathComponent(id + ".agents.d")
+    }
+
+    // Refresh `sessionAgents` from each live session's <sid>.agents.d/. Agent files are
+    // write-once/delete-once, so the DIRECTORY mtime (bumped by every add, delete, and the
+    // atomic rename) is a complete change signal: one stat per session per tick, a readdir+parse
+    // only when something actually changed — same philosophy as fileMTimes above.
+    func reloadAgents() {
+        let fm = FileManager.default
+        for id in Array(sessionAgents.keys) where sessions[id] == nil {
+            sessionAgents[id] = nil; agentDirMTimes[id] = nil
+        }
+        // Sweep orphaned agent dirs (session gone, dir shell left — e.g. a SubagentStop that
+        // raced a turn-boundary reap). Never rendered (no live session), just disk hygiene.
+        for f in ((try? fm.contentsOfDirectory(atPath: stateDir)) ?? []) where f.hasSuffix(".agents.d") {
+            let sid = String(f.dropLast(".agents.d".count))
+            if sessions[sid] == nil {
+                try? fm.removeItem(atPath: (stateDir as NSString).appendingPathComponent(f))
+            }
+        }
+        for id in sessions.keys {
+            let dir = agentsDirPath(id)
+            guard let attrs = try? fm.attributesOfItem(atPath: dir),
+                  let m = attrs[.modificationDate] as? Date else {
+                sessionAgents[id] = nil; agentDirMTimes[id] = nil   // no dir = no running agents
+                continue
+            }
+            if agentDirMTimes[id] == m { continue }
+            agentDirMTimes[id] = m
+            var list: [AgentInfo] = []
+            for f in ((try? fm.contentsOfDirectory(atPath: dir)) ?? []) where f.hasSuffix(".json") {
+                guard let d = fm.contents(atPath: (dir as NSString).appendingPathComponent(f)),
+                      let o = try? JSONSerialization.jsonObject(with: d) as? [String: Any] else { continue }
+                list.append(AgentInfo(json: o, id: (f as NSString).deletingPathExtension))
+            }
+            // Spawn order, id as a stable tiebreak within the same second.
+            sessionAgents[id] = list.sorted { $0.startedAt == $1.startedAt ? $0.id < $1.id : $0.startedAt < $1.startedAt }
         }
     }
 
@@ -985,7 +1229,9 @@ final class StatusController: NSObject, NSMenuDelegate {
                                  : (s.eff == "idle" && stalePruneAge > 0 && now - s.ts > stalePruneAge)
             if dead {
                 try? FileManager.default.removeItem(atPath: (stateDir as NSString).appendingPathComponent(id + ".json"))
+                try? FileManager.default.removeItem(atPath: agentsDirPath(id))
                 sessions[id] = nil; fileMTimes[id + ".json"] = nil; prevState[id] = nil; sessionWord[id] = nil
+                sessionAgents[id] = nil; agentDirMTimes[id] = nil
                 continue
             }
             sessions[id] = s

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ PLIST
 
 # Bundle the hook scripts (so first-launch self-install works) and the app icon.
 mkdir -p "$APP/Contents/Resources"
-cp hooks/update.js hooks/lifecycle.js hooks/install.js hooks/uninstall.js "$APP/Contents/Resources/"
+cp hooks/update.js hooks/lifecycle.js hooks/agents.js hooks/install.js hooks/uninstall.js "$APP/Contents/Resources/"
 cp assets/AppIcon.icns "$APP/Contents/Resources/AppIcon.icns"
 
 # --- Signing / notarization ---

--- a/hooks/agents.js
+++ b/hooks/agents.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// SubagentStart/SubagentStop hooks. Usage: node agents.js <start|stop>  (hook JSON on stdin)
+//
+// One tiny file per RUNNING subagent: ~/.claude/statusbar/state.d/<session_id>.agents.d/<agent_id>.json
+// created on SubagentStart, removed on SubagentStop. Files are independent (atomic tmp+rename),
+// so parallel subagents never race a shared file. update.js/lifecycle.js clear the whole dir on
+// prompt/stop/session boundaries, so a missed SubagentStop (interrupt, crash) can't leave stale
+// entries past the turn.
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const dir = path.join(os.homedir(), ".claude", "statusbar");
+const stateDir = path.join(dir, "state.d");
+const event = process.argv[2];
+
+const safeId = (s) => String(s || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64) || "unknown";
+
+const writeAtomic = (file, obj) => {
+  const tmp = file + "." + process.pid + ".tmp"; // no .json suffix: the app ignores it mid-write
+  fs.writeFileSync(tmp, JSON.stringify(obj));
+  fs.renameSync(tmp, file);
+};
+
+let input = "", done = false;
+process.stdin.on("data", (d) => (input += d));
+process.stdin.on("end", () => run());
+process.stdin.on("error", () => run());
+setTimeout(run, 1000); // hooks always pipe stdin, but never hang the session
+
+function run() {
+  if (done) return; done = true;
+  let p = {};
+  try { p = JSON.parse(input || "{}"); } catch {}
+
+  if (process.env.CLAUDE_STATUSBAR_DEBUG === "1") {
+    try {
+      fs.appendFileSync(path.join(dir, "hooks.log"),
+        `${new Date().toISOString()} [agents:${event}] agent=${p.agent_id || "-"} type=${p.agent_type || "-"} keys=${Object.keys(p).join(",")}\n`);
+    } catch {}
+  }
+
+  // Without both ids there is nothing to key the file on — bail rather than write "unknown".
+  if (!p.session_id || !p.agent_id) process.exit(0);
+  const agentsDir = path.join(stateDir, safeId(p.session_id) + ".agents.d");
+  const agentPath = path.join(agentsDir, safeId(p.agent_id) + ".json");
+
+  if (event === "start") {
+    const ts = Math.floor(Date.now() / 1000);
+    // task is the delegation prompt Claude wrote; keep a one-line snippet for the row + tooltip.
+    const task = String(p.task || "").replace(/\s+/g, " ").trim().slice(0, 200);
+    try {
+      fs.mkdirSync(agentsDir, { recursive: true });
+      writeAtomic(agentPath, {
+        agentType: String(p.agent_type || ""),
+        task,
+        parentAgentId: p.parent_agent_id ? String(p.parent_agent_id) : "",
+        startedAt: ts,
+        ts,
+      });
+    } catch {}
+  } else if (event === "stop") {
+    try { fs.rmSync(agentPath, { force: true }); } catch {}
+    // Last one out sweeps the shell (fails silently while siblings still run). Subagents can
+    // outlive the parent turn (they run in the background), so the turn-boundary reaps in
+    // update.js may have already emptied the dir — this catches the straggler's leftover.
+    try { fs.rmdirSync(agentsDir); } catch {}
+  }
+  process.exit(0);
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -23,6 +23,12 @@
     ],
     "Stop": [
       { "hooks": [{ "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/update.js\" stop" }] }
+    ],
+    "SubagentStart": [
+      { "hooks": [{ "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/agents.js\" start" }] }
+    ],
+    "SubagentStop": [
+      { "hooks": [{ "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/agents.js\" stop" }] }
     ]
   }
 }

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -13,6 +13,7 @@ const sbDir = path.join(home, ".claude", "statusbar");
 const MARKER = sbDir; // every hook command we add points inside this dir
 const updateDest = path.join(sbDir, "update.js");
 const lifecycleDest = path.join(sbDir, "lifecycle.js");
+const agentsDest = path.join(sbDir, "agents.js");
 const settingsPath = path.join(home, ".claude", "settings.json");
 const node = process.execPath;
 
@@ -29,9 +30,11 @@ fs.rmSync(path.join(sbDir, "state.json"), { force: true });
 fs.rmSync(path.join(sbDir, "sessions.d"), { recursive: true, force: true });
 fs.copyFileSync(path.join(__dirname, "update.js"), updateDest);
 fs.copyFileSync(path.join(__dirname, "lifecycle.js"), lifecycleDest);
+fs.copyFileSync(path.join(__dirname, "agents.js"), agentsDest);
 
 const cmd = (evt) => `${node} ${updateDest} ${evt}`;
 const life = (evt) => `${node} ${lifecycleDest} ${evt}`;
+const agents = (evt) => `${node} ${agentsDest} ${evt}`;
 
 let settings = {};
 if (fs.existsSync(settingsPath)) {
@@ -65,11 +68,14 @@ addMatched("PostToolUse", cmd("post"));
 addUnmatched("Notification", cmd("notify"));
 addMatched("PermissionRequest", cmd("permreq"));
 addUnmatched("Stop", cmd("stop"));
+// Subagent hooks (one file per running subagent; drives the indented rows in the dropdown)
+addUnmatched("SubagentStart", agents("start"));
+addUnmatched("SubagentStop", agents("stop"));
 // Lifecycle hooks (launch the app on open; the app quits itself when no longer needed)
 addUnmatched("SessionStart", life("start"));
 addUnmatched("SessionEnd", life("end"));
 
 fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
 console.log("Installed status-bar hooks into", settingsPath);
-console.log("Scripts:", updateDest, "and", lifecycleDest);
+console.log("Scripts:", updateDest + ",", lifecycleDest, "and", agentsDest);
 console.log("Backup (first run only):", settingsPath + ".bak-statusbar");

--- a/hooks/lifecycle.js
+++ b/hooks/lifecycle.js
@@ -35,11 +35,15 @@ function run() {
   try { const j = JSON.parse(input); id = j.session_id; cwd = j.cwd || ""; } catch {}
   id = safeId(id);
   const statePath = path.join(stateDir, id + ".json");
+  const agentsDir = path.join(stateDir, id + ".agents.d");
 
   if (event === "start") {
     // If the app isn't running, any leftover session files are stale (e.g. a prior
-    // crash) — clear them so the count starts honest.
-    if (!running()) { try { for (const f of fs.readdirSync(stateDir)) fs.rmSync(path.join(stateDir, f), { force: true }); } catch {} }
+    // crash) — clear them so the count starts honest. recursive: the sweep must not
+    // abort on <sid>.agents.d directories (rmSync throws EISDIR on them otherwise).
+    if (!running()) { try { for (const f of fs.readdirSync(stateDir)) fs.rmSync(path.join(stateDir, f), { recursive: true, force: true }); } catch {} }
+    // A session start (open/resume/clear) has no active turn, so no live subagents.
+    try { fs.rmSync(agentsDir, { recursive: true, force: true }); } catch {}
     // Seed an idle file: counts the session immediately, and clears any frozen state from a
     // resume (SessionStart fires on resume with no active turn).
     try {
@@ -52,6 +56,7 @@ function run() {
     // Removing the file drops this session from the aggregate — this is also what recovers a
     // frozen animation on force-quit (SessionEnd fires, but no Stop). No state rewrite needed.
     try { fs.rmSync(statePath, { force: true }); } catch {}
+    try { fs.rmSync(agentsDir, { recursive: true, force: true }); } catch {}
   }
   process.exit(0);
 }

--- a/hooks/update.js
+++ b/hooks/update.js
@@ -14,7 +14,7 @@ const TOOL_LABELS = {
   Bash: "Running command", Edit: "Editing", Write: "Writing", MultiEdit: "Editing",
   NotebookEdit: "Editing", Read: "Reading", Grep: "Searching", Glob: "Searching",
   WebFetch: "Browsing web", WebSearch: "Searching web", Task: "Delegating",
-  TodoWrite: "Planning",
+  Agent: "Delegating", TodoWrite: "Planning",
 };
 
 const safeId = (s) => String(s || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64) || "unknown";
@@ -77,6 +77,10 @@ process.stdin.on("end", () => {
       // Desktop-app permission signal; not redundant with notify (that's CLI-only).
       state = "permission"; label = "Awaiting permission"; startedAt = 0; break;
     case "stop":
+      // NOTE: running-subagent files (<sid>.agents.d/, written by agents.js) deliberately survive
+      // the turn: subagents run in the BACKGROUND and outlive the parent's turn — Stop fires
+      // seconds after the spawn while they're still working. Their files are removed by their
+      // own SubagentStop; lifecycle.js clears the dir at session boundaries.
       state = "done"; label = "Done"; startedAt = 0; break;
     default:
       return;


### PR DESCRIPTION
## What this changes

When Claude fans work out to subagents (the Task/Agent tool), each **running** subagent now shows as a small indented row under its session in the dropdown: a Claude Code-style status dot (dim grey while running, green once finished — matching the CLI's own task list), the agent type, plus the delegation-prompt snippet when Claude Code provides one, and its own elapsed timer.

```
Sessions
 ◌  myrepo · main          1m 12s  CLI
     ● Explore              41s
     ● general-purpose      12s
 ❯  other-project · fix-x        CLI
```

**How it works** — one tiny JSON per running subagent in `~/.claude/statusbar/state.d/<sid>.agents.d/<agent_id>.json`, written by a new `agents.js` on `SubagentStart`, removed on `SubagentStop`. Files are independent (atomic tmp+rename), so parallel subagents never race a shared file and the hooks stay fire-write-exit. The app stats each session's dir mtime on its existing 0.4s tick (agent files are write-once, so the dir mtime is a complete change signal) and re-parses only on change — the same `fileMTimes` philosophy the session files already use. Zero cost when no subagents are running: no dir, one failed stat per session per tick.

**Subagents run in the background and outlive the turn that spawned them** — in real traces the parent's `Stop` fires seconds after the spawn while the agents keep working. So a row lives exactly as long as its file (`SubagentStart` → `SubagentStop`), regardless of what the parent is doing, and a session with live agents is exempt from the idle-hide filter (background work shouldn't read as stale). Belts against a `SubagentStop` lost to a crash: `lifecycle.js` clears the dir at session boundaries (start/resume/end), the app reaps it with a dead session's state file and sweeps orphaned dir shells, and an `agentMaxAge` display cap (default 7200s, same order as the permission cap) bounds the worst case.

Menu-open semantics follow the session rows' constraint (NSMenu can't add/remove items mid-track): an agent that finishes while the menu is open settles in place — dot flips green, text dims, timer freezes — and the next open drops the row; agents that start while open appear on the next open. Fan-outs cap at 4 rows plus a dim "+ k more" line (`agentRowsMax`, `agentRowH`, `agentIndent`, `agentDotSize` are uiconfig knobs, same live-tunable pattern as `boxWidth`).

Two adjacent fixes bundled because this feature is what exposes them:
- `lifecycle.js`'s stale sweep aborted on the first *directory* it hit (non-recursive `rmSync` inside a single `try`) — it never mattered before because `state.d/` only held files; now it must survive `.agents.d` dirs, so the sweep is recursive.
- `TOOL_LABELS` now maps the Task tool's current name **"Agent"** to "Delegating" (verified in real `PreToolUse` payloads — the old "Task" name stays mapped). Without it the parent row says "Using tool" during a fan-out.

**Verified against real payloads**, not just docs: headless runs with the debug hook log show `SubagentStart`/`SubagentStop` firing with `agent_id` + `agent_type` as documented; `task`/`parent_agent_id` turn out to be absent in practice, so the row degrades to type-only and picks the snippet up if/when Claude Code sends it. An earlier iteration cleared agent files at turn boundaries — the traces showed that wipes live background agents (parent `Stop` at t+8s, second `SubagentStop` at t+12s), so the shipped design keys entirely on the subagent's own lifecycle; a per-second file-count trace across a live fan-out confirms files persist through the parent's `Stop` and vanish exactly at each agent's own stop, with no leftovers.

## Issue

None — new display feature. Fits "What's welcome" (visual polish / showing Claude Code's live status); checked #22 for overlap, none tracked.

## How you tested it

- [x] Tested in the **Claude desktop app**
- [x] Tested in the **CLI, in a terminal**
- **Which terminal did you use?** iTerm2
- **What you did and what you saw:**
  - In an iTerm2 session, prompted Claude to spawn two parallel subagents (one Explore, one general-purpose). Two files appeared in `<sid>.agents.d/`, and the dropdown showed both indented rows — grey dots, independently ticking timers — that persisted after the parent's turn ended, for as long as the agents actually ran.
  - Kept the menu open while one agent finished: its dot flipped green with the timer frozen; on reopen the row was gone.
  - Headless `claude -p` runs with the hook debug log to capture real payload keys (that's where the "Agent" tool name and the missing `task` field were discovered), plus a per-second file-count trace over a live fan-out: `0 → 1 → 2 → 1 → 0`, files surviving the parent's `Stop` and vanishing at each agent's own `SubagentStop`, no leftover dirs after session end.
  - Logic-level: extracted `reloadAgents`/`visibleAgents`/`AgentInfo` verbatim into a compile harness — 11 scenarios pass (spawn-order sorting, background agents visible under an idle parent, age-cap on a crash-orphaned agent, `.tmp` files ignored, dir reap, orphan cleanup, defensive parsing). Hook-side: scripted round-trip of start/stop/session boundaries and the recursive stale sweep against a sandboxed `$HOME`.
  - Regression: sessions without subagents render identically to 0.3.4; `uninstall.js` removes all 10 hook entries (it strips by marker, so the two new events are covered without changes).

## Checklist
- [x] I built off the latest `main`, so I'm not fixing something that already changed.
- [x] One focused change, not a bundle of unrelated edits.
- [x] Screenshot or short screen recording attached for any visual or timing change.
- [x] I read CONTRIBUTING.md and the known issues (#22), and this fits the scope.

## Is this for everyone, or is it your fork?

For everyone — it surfaces a core Claude Code behavior (subagent fan-out) that's currently invisible in the bar, using only the documented hook surface, staying local and tiny.
