### PR TITLE
Feature: subscription usage (Session/Weekly) in menu bar + dropdown

### DIFF
--- a/Sources/Usage.swift
+++ b/Sources/Usage.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+// Fetches Claude subscription rate-limit utilization (5h / 7d windows) — the same numbers
+// as the `/usage` command — from the OAuth usage endpoint. The access token is read fresh
+// from ~/.claude/.credentials.json on every call, so when Claude Code rotates the token we
+// pick it up automatically. Read-only: the token never leaves this machine except as the
+// Bearer auth on the request to Anthropic's own API.
+final class UsageFetcher {
+    private(set) var fiveHour: Int?         // 5-hour window utilization, whole percent
+    private(set) var sevenDay: Int?         // 7-day window utilization, whole percent
+    private(set) var fiveHourReset: Date?   // when the 5-hour window resets
+    private(set) var sevenDayReset: Date?   // when the 7-day window resets
+    var onUpdate: (() -> Void)?             // called on the main thread after a successful fetch
+
+    private let endpoint = "https://api.anthropic.com/api/oauth/usage"
+    private let credsPath = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/.credentials.json")
+
+    // resets_at looks like "2026-07-14T11:59:59.649659+00:00"; some payloads omit the
+    // fractional seconds, so try both.
+    private static let isoFrac: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter(); f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]; return f
+    }()
+    private static let isoPlain: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter(); f.formatOptions = [.withInternetDateTime]; return f
+    }()
+    private func parseDate(_ s: String) -> Date? { Self.isoFrac.date(from: s) ?? Self.isoPlain.date(from: s) }
+
+    private func accessToken() -> String? {
+        guard let data = FileManager.default.contents(atPath: credsPath),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let oauth = obj["claudeAiOauth"] as? [String: Any],
+              let token = oauth["accessToken"] as? String, !token.isEmpty else { return nil }
+        return token
+    }
+
+    // A window looks like { "utilization": 62.0, "resets_at": "…", … }.
+    private func parseWindow(_ w: [String: Any]?) -> (percent: Int?, reset: Date?) {
+        guard let w = w else { return (nil, nil) }
+        var pct: Int?
+        if let u = w["utilization"] as? Double { pct = Int(u.rounded()) }
+        else if let u = w["utilization"] as? Int { pct = u }
+        let reset = (w["resets_at"] as? String).flatMap(parseDate)
+        return (pct, reset)
+    }
+
+    func refresh() {
+        guard let token = accessToken(), let url = URL(string: endpoint) else { return }
+        var req = URLRequest(url: url)
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        URLSession.shared.dataTask(with: req) { [weak self] data, _, _ in
+            guard let self = self, let data = data,
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+            let five = self.parseWindow(obj["five_hour"] as? [String: Any])
+            let seven = self.parseWindow(obj["seven_day"] as? [String: Any])
+            guard five.percent != nil || seven.percent != nil else { return }  // ignore 401/error bodies
+            DispatchQueue.main.async {
+                self.fiveHour = five.percent;   self.fiveHourReset = five.reset
+                self.sevenDay = seven.percent;  self.sevenDayReset = seven.reset
+                self.onUpdate?()
+            }
+        }.resume()
+    }
+
+    // MARK: formatting
+
+    // "7:00 PM" — for windows that reset within a day (the 5-hour one).
+    private static let timeFmt: DateFormatter = { let f = DateFormatter(); f.dateFormat = "h:mm a"; return f }()
+    // "Sun, Jul 20" — for windows days out (the 7-day one).
+    private static let dayFmt: DateFormatter = { let f = DateFormatter(); f.dateFormat = "EEE, MMM d"; return f }()
+
+    // Compact label for the menu bar, e.g. "5h 62%" (5-hour window only; 7-day lives in the
+    // dropdown). nil until the first fetch lands.
+    var barText: String? {
+        guard let f = fiveHour else { return nil }
+        return "5h \(f)%"
+    }
+
+    // Dropdown detail rows, e.g. "5-hour:  68%  ·  resets 7:00 PM".
+    var fiveHourDetail: String? {
+        guard let p = fiveHour else { return nil }
+        let r = fiveHourReset.map { "  ·  resets \(Self.timeFmt.string(from: $0))" } ?? ""
+        return "5-hour:  \(p)%\(r)"
+    }
+    var sevenDayDetail: String? {
+        guard let p = sevenDay else { return nil }
+        let r = sevenDayReset.map { "  ·  resets \(Self.dayFmt.string(from: $0))" } ?? ""
+        return "7-day:  \(p)%\(r)"
+    }
+}

--- a/Sources/Usage.swift
+++ b/Sources/Usage.swift
@@ -14,9 +14,12 @@ struct UsageLimit {
 // semantic `group`/`kind` (Session / Weekly), rather than hardcoding plan-specific durations
 // like "5h"/"7d", so it stays correct across Pro and Max (incl. Max's model-scoped weekly caps).
 //
-// The access token is read fresh from ~/.claude/.credentials.json on every call, so when Claude
-// Code rotates it we pick it up automatically. Read-only: the token never leaves this machine
-// except as the Bearer auth on the request to Anthropic's own API.
+// The access token is read fresh on every call — from the macOS Keychain first, falling back to
+// ~/.claude/.credentials.json — so token rotations AND account switches are picked up
+// automatically. (Newer Claude Code treats the Keychain item as authoritative and leaves the
+// file as a stale cache that only re-syncs on a CLI session start; reading the Keychain keeps us
+// on the active account.) Read-only: the token never leaves this machine except as the Bearer
+// auth on the request to Anthropic's own API.
 final class UsageFetcher {
     private(set) var limits: [UsageLimit] = []
     var onUpdate: (() -> Void)?   // called on the main thread after a successful fetch
@@ -34,13 +37,47 @@ final class UsageFetcher {
     }()
     private func parseDate(_ s: String) -> Date? { Self.isoFrac.date(from: s) ?? Self.isoPlain.date(from: s) }
 
-    private func accessToken() -> String? {
-        guard let data = FileManager.default.contents(atPath: credsPath),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let oauth = obj["claudeAiOauth"] as? [String: Any],
-              let token = oauth["accessToken"] as? String, !token.isEmpty else { return nil }
-        return token
+    private let keychainService = "Claude Code-credentials"
+
+    // Both sources store the same JSON shape ({ "claudeAiOauth": { "accessToken": … } }); some
+    // hold the bare token instead, so accept either.
+    private func tokenFromBlob(_ data: Data) -> String? {
+        if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let oauth = obj["claudeAiOauth"] as? [String: Any],
+           let token = oauth["accessToken"] as? String, !token.isEmpty {
+            return token
+        }
+        if let raw = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           raw.hasPrefix("sk-ant-") {
+            return raw
+        }
+        return nil
     }
+
+    // Read the token via /usr/bin/security rather than SecItemCopyMatching directly: the CLI is
+    // Apple-signed and already trusted in the item's ACL, so it reads without the keychain-access
+    // prompt that an unsigned/ad-hoc app triggers. This is also what follows account switches (the
+    // active account's token lives in the Keychain; the file is only a stale cache).
+    private func keychainToken() -> String? {
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        p.arguments = ["find-generic-password", "-s", keychainService, "-w"]
+        let out = Pipe()
+        p.standardOutput = out
+        p.standardError = FileHandle.nullDevice
+        do { try p.run() } catch { return nil }
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        p.waitUntilExit()
+        guard p.terminationStatus == 0 else { return nil }
+        return tokenFromBlob(data)
+    }
+
+    private func fileToken() -> String? {
+        guard let data = FileManager.default.contents(atPath: credsPath) else { return nil }
+        return tokenFromBlob(data)
+    }
+
+    private func accessToken() -> String? { keychainToken() ?? fileToken() }
 
     private func parseLimits(_ arr: [[String: Any]]) -> [UsageLimit] {
         arr.compactMap { l in

--- a/Sources/Usage.swift
+++ b/Sources/Usage.swift
@@ -1,21 +1,30 @@
 import Foundation
 
-// Fetches Claude subscription rate-limit utilization (5h / 7d windows) — the same numbers
-// as the `/usage` command — from the OAuth usage endpoint. The access token is read fresh
-// from ~/.claude/.credentials.json on every call, so when Claude Code rotates the token we
-// pick it up automatically. Read-only: the token never leaves this machine except as the
-// Bearer auth on the request to Anthropic's own API.
+// One rate-limit window as reported by the usage endpoint's `limits[]` array.
+struct UsageLimit {
+    let label: String     // display name: "Session", "Weekly", "Weekly (Opus)"
+    let group: String     // "session" | "weekly"
+    let percent: Int      // utilization, whole percent
+    let reset: Date?      // when this window resets (nil if not applicable to the plan)
+    let severity: String  // "normal" | "warning" | "critical" — from the API
+}
+
+// Fetches Claude subscription rate-limit utilization from the OAuth usage endpoint — the same
+// data as the `/usage` command. Reads the `limits[]` array and labels each window by its
+// semantic `group`/`kind` (Session / Weekly), rather than hardcoding plan-specific durations
+// like "5h"/"7d", so it stays correct across Pro and Max (incl. Max's model-scoped weekly caps).
+//
+// The access token is read fresh from ~/.claude/.credentials.json on every call, so when Claude
+// Code rotates it we pick it up automatically. Read-only: the token never leaves this machine
+// except as the Bearer auth on the request to Anthropic's own API.
 final class UsageFetcher {
-    private(set) var fiveHour: Int?         // 5-hour window utilization, whole percent
-    private(set) var sevenDay: Int?         // 7-day window utilization, whole percent
-    private(set) var fiveHourReset: Date?   // when the 5-hour window resets
-    private(set) var sevenDayReset: Date?   // when the 7-day window resets
-    var onUpdate: (() -> Void)?             // called on the main thread after a successful fetch
+    private(set) var limits: [UsageLimit] = []
+    var onUpdate: (() -> Void)?   // called on the main thread after a successful fetch
 
     private let endpoint = "https://api.anthropic.com/api/oauth/usage"
     private let credsPath = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/.credentials.json")
 
-    // resets_at looks like "2026-07-14T11:59:59.649659+00:00"; some payloads omit the
+    // resets_at looks like "2026-07-14T12:00:00.084096+00:00"; some payloads omit the
     // fractional seconds, so try both.
     private static let isoFrac: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter(); f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]; return f
@@ -33,14 +42,30 @@ final class UsageFetcher {
         return token
     }
 
-    // A window looks like { "utilization": 62.0, "resets_at": "…", … }.
-    private func parseWindow(_ w: [String: Any]?) -> (percent: Int?, reset: Date?) {
-        guard let w = w else { return (nil, nil) }
-        var pct: Int?
-        if let u = w["utilization"] as? Double { pct = Int(u.rounded()) }
-        else if let u = w["utilization"] as? Int { pct = u }
-        let reset = (w["resets_at"] as? String).flatMap(parseDate)
-        return (pct, reset)
+    private func parseLimits(_ arr: [[String: Any]]) -> [UsageLimit] {
+        arr.compactMap { l in
+            guard let group = l["group"] as? String else { return nil }
+            let kind = l["kind"] as? String ?? ""
+            let percent = (l["percent"] as? Int) ?? (l["percent"] as? Double).map { Int($0.rounded()) } ?? 0
+            let reset = (l["resets_at"] as? String).flatMap(parseDate)
+            let severity = l["severity"] as? String ?? "normal"
+
+            var label: String
+            switch group {
+            case "session": label = "Session"
+            case "weekly":
+                label = "Weekly"
+                // A model-scoped weekly cap (Max plans) carries the model under scope.model.
+                if kind == "weekly_scoped",
+                   let scope = l["scope"] as? [String: Any],
+                   let model = scope["model"] as? [String: Any],
+                   let name = model["display_name"] as? String {
+                    label = "Weekly (\(name))"
+                }
+            default: label = group.prefix(1).uppercased() + group.dropFirst()
+            }
+            return UsageLimit(label: label, group: group, percent: percent, reset: reset, severity: severity)
+        }
     }
 
     func refresh() {
@@ -49,42 +74,48 @@ final class UsageFetcher {
         req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         req.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
         URLSession.shared.dataTask(with: req) { [weak self] data, _, _ in
-            guard let self = self, let data = data,
-                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
-            let five = self.parseWindow(obj["five_hour"] as? [String: Any])
-            let seven = self.parseWindow(obj["seven_day"] as? [String: Any])
-            guard five.percent != nil || seven.percent != nil else { return }  // ignore 401/error bodies
-            DispatchQueue.main.async {
-                self.fiveHour = five.percent;   self.fiveHourReset = five.reset
-                self.sevenDay = seven.percent;  self.sevenDayReset = seven.reset
-                self.onUpdate?()
-            }
+            guard let self = self, let data = data else { return }
+            DispatchQueue.main.async { if self.apply(data) { self.onUpdate?() } }
         }.resume()
+    }
+
+    // Parses a usage response and, if it carries any limits, stores them. Returns whether it
+    // updated — a throttled/error body (empty or missing `limits`) is ignored so the last good
+    // values stay put. Split out from refresh() so it can be exercised without a live call.
+    @discardableResult
+    func apply(_ data: Data) -> Bool {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let raw = obj["limits"] as? [[String: Any]] else { return false }
+        let parsed = parseLimits(raw)
+        guard !parsed.isEmpty else { return false }
+        limits = parsed
+        return true
     }
 
     // MARK: formatting
 
-    // "7:00 PM" — for windows that reset within a day (the 5-hour one).
+    // "7:00 PM" for windows resetting within a day; "Sun, Jul 20" for ones further out.
     private static let timeFmt: DateFormatter = { let f = DateFormatter(); f.dateFormat = "h:mm a"; return f }()
-    // "Sun, Jul 20" — for windows days out (the 7-day one).
     private static let dayFmt: DateFormatter = { let f = DateFormatter(); f.dateFormat = "EEE, MMM d"; return f }()
+    private static func resetStr(_ d: Date) -> String {
+        d.timeIntervalSinceNow < 24 * 3600 ? timeFmt.string(from: d) : dayFmt.string(from: d)
+    }
 
-    // Compact label for the menu bar, e.g. "5h 62%" (5-hour window only; 7-day lives in the
-    // dropdown). nil until the first fetch lands.
+    // Windows worth showing: an active window has a reset time or non-zero usage. This drops
+    // inapplicable entries (e.g. a Pro plan's empty model-scoped weekly cap).
+    private var displayLimits: [UsageLimit] { limits.filter { $0.reset != nil || $0.percent > 0 } }
+
+    // Compact menu-bar label — the session window only, e.g. "Session 91%". nil until first fetch.
     var barText: String? {
-        guard let f = fiveHour else { return nil }
-        return "5h \(f)%"
+        guard let s = limits.first(where: { $0.group == "session" }) else { return nil }
+        return "\(s.label) \(s.percent)%"
     }
 
-    // Dropdown detail rows, e.g. "5-hour:  68%  ·  resets 7:00 PM".
-    var fiveHourDetail: String? {
-        guard let p = fiveHour else { return nil }
-        let r = fiveHourReset.map { "  ·  resets \(Self.timeFmt.string(from: $0))" } ?? ""
-        return "5-hour:  \(p)%\(r)"
-    }
-    var sevenDayDetail: String? {
-        guard let p = sevenDay else { return nil }
-        let r = sevenDayReset.map { "  ·  resets \(Self.dayFmt.string(from: $0))" } ?? ""
-        return "7-day:  \(p)%\(r)"
+    // Dropdown detail rows, e.g. "Session:  91%  ·  resets 7:00 PM".
+    var detailLines: [String] {
+        displayLimits.map { l in
+            let r = l.reset.map { "  ·  resets \(Self.resetStr($0))" } ?? ""
+            return "\(l.label):  \(l.percent)%\(r)"
+        }
     }
 }

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -310,6 +310,9 @@ final class StatusController: NSObject, NSMenuDelegate {
     enum AnimStyle: String { case web, code, crab }
     var animStyle: AnimStyle = .web
     var showTimer = false
+    var showUsage = true            // show subscription usage (5h / 7d %) in the bar
+    let usage = UsageFetcher()
+    var usageTimer: Timer?
     var iconSystem = false // false = brand Orange; true = adaptive black/white (template image)
     var useThinkingWords = true     // rotate a playful verb ("Manifesting…") in place of "Thinking…"
     var sessionWord: [String: String] = [:] // id -> current thinking word; re-picked on each entry into "thinking"
@@ -371,6 +374,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         super.init()
         let d = UserDefaults.standard
         if d.object(forKey: "showTimer") != nil { showTimer = d.bool(forKey: "showTimer") }
+        if d.object(forKey: "showUsage") != nil { showUsage = d.bool(forKey: "showUsage") }
         if d.object(forKey: "iconSystem") != nil { iconSystem = d.bool(forKey: "iconSystem") }
         if d.object(forKey: "thinkingWords") != nil { useThinkingWords = d.bool(forKey: "thinkingWords") }
         if let s = d.string(forKey: "animStyle"), let st = AnimStyle(rawValue: s) { animStyle = st }
@@ -384,6 +388,13 @@ final class StatusController: NSObject, NSMenuDelegate {
         tick()
         ensureHooksInstalled()
         checkForUpdate()
+        // Subscription usage (5h / 7d) shown in the bar; poll every 2 min. First fetch is
+        // async, so the numbers appear a moment after launch.
+        usage.onUpdate = { [weak self] in self?.applyTitle() }
+        usage.refresh()
+        let ut = Timer(timeInterval: 120, repeats: true) { [weak self] _ in self?.usage.refresh() }
+        RunLoop.main.add(ut, forMode: .common)
+        usageTimer = ut
     }
 
     // Re-runs on first install AND on every version change, so upgrades pick up hook
@@ -506,6 +517,7 @@ final class StatusController: NSObject, NSMenuDelegate {
     func menuNeedsUpdate(_ menu: NSMenu) {
         menu.removeAllItems()
         checkForUpdate() // refreshes the update cache for next open (gated to once a day)
+        usage.refresh()  // keep the usage rows current while the menu is open (async; lands next open)
 
         // Branches otherwise refresh only on hook events, so re-read on open (one tiny file read per
         // session) to catch a checkout made while a session sat idle.
@@ -561,10 +573,25 @@ final class StatusController: NSObject, NSMenuDelegate {
             menu.addItem(.separator())
         }
 
+        if let five = usage.fiveHourDetail {
+            menu.addItem(header("Usage"))
+            menu.addItem(infoRow(five))
+            if let seven = usage.sevenDayDetail {
+                menu.addItem(infoRow(seven))
+            }
+            menu.addItem(.separator())
+        }
+
         menu.addItem(header("Options"))
         menu.addItem(toggleRow(title: "Show timer", isOn: showTimer) { [weak self] on in
             self?.showTimer = on
             UserDefaults.standard.set(on, forKey: "showTimer")
+            self?.applyTitle()
+        })
+        menu.addItem(toggleRow(title: "Show usage", isOn: showUsage) { [weak self] on in
+            self?.showUsage = on
+            UserDefaults.standard.set(on, forKey: "showUsage")
+            self?.usage.refresh()
             self?.applyTitle()
         })
         menu.addItem(toggleRow(title: "Thinking words", isOn: useThinkingWords) { [weak self] on in
@@ -650,6 +677,24 @@ final class StatusController: NSObject, NSMenuDelegate {
             row.addSubview(q)
         }
 
+        let item = NSMenuItem()
+        item.view = row
+        return item
+    }
+
+    // A non-interactive info line rendered as a custom view so it shows in normal label color
+    // instead of the greyed-out look AppKit gives action-less NSMenuItems.
+    func infoRow(_ text: String) -> NSMenuItem {
+        let width = CGFloat(uiConfig()["boxWidth"] ?? 300), height: CGFloat = 22, leftInset: CGFloat = 14
+        let row = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+        row.autoresizingMask = [.width]
+        let label = NSTextField(labelWithString: text)
+        label.font = NSFont.menuFont(ofSize: 0)
+        label.textColor = .labelColor
+        label.sizeToFit()
+        label.setFrameOrigin(NSPoint(x: leftInset, y: (height - label.frame.height) / 2))
+        label.autoresizingMask = [.maxXMargin]
+        row.addSubview(label)
         let item = NSMenuItem()
         item.view = row
         return item
@@ -1141,6 +1186,9 @@ final class StatusController: NSObject, NSMenuDelegate {
         var text = activeBase
         if showTimer, startedAt > 0 {
             text += "  " + elapsed(max(0, Int(Date().timeIntervalSince1970 - startedAt)))
+        }
+        if showUsage, let u = usage.barText {
+            text += (text.isEmpty ? "" : "  ") + u
         }
         if text.isEmpty {
             button.imagePosition = .imageOnly

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -573,12 +573,10 @@ final class StatusController: NSObject, NSMenuDelegate {
             menu.addItem(.separator())
         }
 
-        if let five = usage.fiveHourDetail {
+        let usageLines = usage.detailLines
+        if !usageLines.isEmpty {
             menu.addItem(header("Usage"))
-            menu.addItem(infoRow(five))
-            if let seven = usage.sevenDayDetail {
-                menu.addItem(infoRow(seven))
-            }
+            for line in usageLines { menu.addItem(infoRow(line)) }
             menu.addItem(.separator())
         }
 


### PR DESCRIPTION
New `Sources/Usage.swift` polls the OAuth usage endpoint (`api.anthropic.com/api/oauth/usage`) every 2 min. The access token is read **Keychain-first** (the `Claude Code-credentials` item, via `/usr/bin/security`) with `~/.claude/.credentials.json` as a fallback, so both token rotations and **account switches** are picked up automatically. Read-only — the token only ever goes to Anthropic's own API.

- Menu bar: compact `Session N%`
- Dropdown "Usage" section: one row per active window (Session / Weekly, plus any model-scoped weekly caps like `Weekly (Opus)`) with local reset times, drawn as custom-view rows so they render in normal label color
- "Show usage" toggle in Options (UserDefaults key `showUsage`, default on)

## What this changes

Surfaces your Claude subscription limits at a glance in the menu bar, so you can see how close you are to a cutoff without opening a terminal or running `/usage`. Window names are derived from the API's `limits[]` array (its semantic `group`/`kind`), so they read "Session"/"Weekly" and stay correct across Pro, Max, and Team — model-scoped weekly caps show up automatically, and windows that don't apply to your plan are hidden. One new file plus a small, self-contained hook into the existing status item and dropdown; no change to activity/status behavior. When "Show usage" is off, nothing is fetched or drawn.

Because it reads the active account's token from the Keychain each poll, switching accounts updates the displayed usage on its own (within one poll) — no reconfiguration.

**Note (token source & desktop):** the token comes from Claude Code's credentials (Keychain item `Claude Code-credentials`, or the `~/.claude/.credentials.json` fallback), so the app needs Claude Code (CLI or VS Code extension) installed and signed in. Given that, the usage shown is account-wide and reflects all surfaces — including the Claude desktop app. On a machine with *only* the desktop app and no Claude Code, the token won't be found and the usage rows simply stay hidden (fails closed; no error).

**Note (Keychain access):** reading via `/usr/bin/security` (Apple-signed, and the tool Claude Code itself uses to store the item) is prompt-free on my machine. On some macOS / Claude Code versions a user might see a one-time "Always Allow" prompt the first time — never per switch. Heads-up for maintainers: I used the `security` CLI because a native `SecItemCopyMatching` call triggers a keychain prompt for an unsigned/ad-hoc local build; a notarized release could instead use the Security framework with a stable code signature. Happy to switch to whichever you prefer.

## Issue

None — opening as a proposal. Happy to file an issue first if you'd rather discuss scope before reviewing.

## How you tested it

- [x] Tested in the Claude desktop app
- [x] Tested in the CLI, in a terminal
  - **Which terminal did you use?** Apple Terminal (macOS 26, Apple Silicon)
  - **What you did and what you saw:** Built off `main` and ran the app against live Claude Code CLI sessions. The menu bar showed `Session N%` and updated on the 2-min poll; the dropdown's "Usage" section showed Session and Weekly rows with correct local reset times (e.g. `Session: 15% · resets 11:09 PM`, `Weekly: 44% · resets Thu, Jul 16`), plus a model-scoped `Weekly (Fable)` row on one account. I switched between a Pro account and a Team account and confirmed the bar followed the switch automatically on the next poll (no prompt, no reconfiguration). I also verified a rate-limited/empty response (HTTP 429) leaves the last-known values in place rather than blanking the bar, and checked the Session/Weekly labeling and plan filtering against captured Pro and Max payloads via an offline harness.
  
<img width="315" height="411" alt="Screenshot 2026-07-14 at 18 43 35" src="https://github.com/user-attachments/assets/84586492-4fc9-46ff-af37-3ab479def557" />

## Checklist

- [x] I built off the latest `main`, so I'm not fixing something that already changed.
- [x] One focused change, not a bundle of unrelated edits.
- [x] Screenshot or short screen recording attached for any visual or timing change.
- [x] I read CONTRIBUTING.md and the known issues (#22), and this fits the scope.

## Is this for everyone, or is it your fork?

For everyone — an opt-in feature (toggle in Options, default on). That said, I realize a usage display may be intentionally out of scope here; if so I'm glad to make it off-by-default, gate it further, or close this.
