### PR TITLE
fix: superseded old-named copy hands off to the newer one instead of winning forever

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -458,6 +458,9 @@ final class StatusController: NSObject, NSMenuDelegate {
         pollTimer = t
         tick()
         try? FileManager.default.removeItem(atPath: (NSHomeDirectory() as NSString).appendingPathComponent(".claude/statusbar/quit-intent"))
+        // Superseded old-named copy: hand off and stop here, so it never installs its older hooks
+        // over the newer copy's (see retireIfSuperseded).
+        if retireIfSuperseded() { return }
         removeOldNamedBundle()
         ensureHooksInstalled()
         checkForUpdate()
@@ -477,6 +480,70 @@ final class StatusController: NSObject, NSMenuDelegate {
             app.forceTerminate()
         }
         try? FileManager.default.removeItem(atPath: old)
+    }
+
+    // The other half of the 0.4.0 rename transition: this copy IS the old-named one, and a newer
+    // copy is installed alongside it. Both bundles carry the same id, so the hooks' self-heal
+    // (`open -g -b <id>`) resolves between them arbitrarily, and on a machine that resolves to this
+    // one, removeOldNamedBundle() above can never run — the bundle that needs deleting is the only
+    // one ever executing, so it returns at that first guard, reinstalls its own older hooks over the
+    // newer ones, and keeps offering an update that never takes effect however many times the DMG is
+    // reinstalled. Hand off to the newer copy instead and retire.
+    //
+    // Returns true when a handoff started, so init() stops setting up: the hook install must NOT run
+    // here. It races the newer copy's install, and this copy would be writing the OLDER hooks.
+    func retireIfSuperseded() -> Bool {
+        guard Bundle.main.bundlePath == "/Applications/ClaudeStatusBar.app",
+              let newer = newerInstalledCopy() else { return false }
+        handOffAndRetire(to: newer)
+        return true
+    }
+
+    // The highest-versioned installed copy of this same app that is strictly newer than this one.
+    // Restricted to /Applications on purpose: a still-mounted DMG stays registered with
+    // LaunchServices long after the drag (so /Volumes must never be the target), and a dev build
+    // in someone's project folder shouldn't be either — the same reason the caller skips
+    // old-named dev builds. Strictly newer, so equal versions can't start a launch loop.
+    func newerInstalledCopy() -> URL? {
+        guard let id = Bundle.main.bundleIdentifier else { return nil }
+        let version = { (u: URL) in
+            (Bundle(url: u)?.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "0"
+        }
+        return NSWorkspace.shared.urlsForApplications(withBundleIdentifier: id)
+            .filter { $0.deletingLastPathComponent().path == "/Applications" }
+            .filter { $0.path != Bundle.main.bundlePath }
+            .filter { versionIsNewer(version($0), than: currentVersion) }
+            .max { versionIsNewer(version($1), than: version($0)) }
+    }
+
+    // Launch the newer copy, delete our own bundle, then exit. Only ever called from the old-named
+    // path above, so the bundle removed here is always that superseded copy.
+    //
+    // createsNewApplicationInstance is required, not optional: we are ourselves a running instance
+    // of this bundle id, and without it LaunchServices ignores the URL and hands back the instance
+    // already running (us) with no error, so the handoff silently no-ops and quitting leaves no
+    // status bar at all. Only a new-instance request actually starts the other bundle.
+    //
+    // We delete our own bundle rather than leaving it to the newer copy's cleanup above: that path
+    // force-terminates us and removes the bundle right after, but forceTerminate is asynchronous, so
+    // whether the removal lands depends on how fast we exit. Retiring ourselves takes the race out
+    // of it — unlinking a running bundle is fine, the process keeps going until it terminates.
+    //
+    // NSApp.terminate rather than quit(): quit() writes the quit-intent marker that suppresses the
+    // hooks' relaunch, and this is a handoff, not the user asking for no status bar. Acting only on
+    // success leaves us running if the launch failed, so a failure degrades to the old behaviour
+    // (a stale icon) instead of no icon at all.
+    func handOffAndRetire(to url: URL) {
+        let cfg = NSWorkspace.OpenConfiguration()
+        cfg.activates = false
+        cfg.createsNewApplicationInstance = true
+        NSWorkspace.shared.openApplication(at: url, configuration: cfg) { app, _ in
+            // Act only once the copy we asked for is the one that actually came up — a request
+            // satisfied by some other instance must not take the status bar down with it.
+            guard app?.bundleURL?.standardizedFileURL.path == url.standardizedFileURL.path else { return }
+            try? FileManager.default.removeItem(atPath: Bundle.main.bundlePath)
+            DispatchQueue.main.async { NSApp.terminate(nil) }
+        }
     }
 
     // Re-runs on first install AND on every version change, so upgrades pick up hook


### PR DESCRIPTION
## What this changes

A pre-0.4.0 copy at `/Applications/ClaudeStatusBar.app` can win the launch race against the renamed bundle forever, which pins the machine to the old version and makes `removeOldNamedBundle()` unreachable. Full root cause and evidence in #45.

Short version: both bundles carry `com.local.claudestatusbar`, so the hooks' self-heal (`open -g -b <id>`) resolves between them arbitrarily. On a machine that resolves to the old copy, the cleanup can never run. The bundle that needs deleting is the only one ever executing, so it returns at the `Bundle.main.bundlePath != old` guard, reinstalls its own older hooks over the newer ones, and keeps offering an update that never takes effect however many times the DMG is reinstalled.

This adds the other half of that transition: the old-named copy now recognises it's superseded, hands off to the newest copy in `/Applications`, deletes its own bundle, and exits. The newer copy then owns the status bar and installs its own hooks. Converges in one pass.

`removeOldNamedBundle()` is unchanged. The diff only adds `retireIfSuperseded()`, two helpers, and one line in `init()`.

Three details that are load-bearing, each of which I got wrong first and fixed after testing:

- **`createsNewApplicationInstance` must be `true`.** We are ourselves a running instance of this bundle id, and without it LaunchServices ignores the URL and hands back the already-running instance (us) reporting `error: none`. The handoff silently no-ops, and quitting then leaves no status bar at all. Verified with a standalone harness: a resident app holding the id, and `openApplication(at:)` returning that resident's pid and path instead of the one requested.
- **`init()` returns right after starting the handoff.** Letting it fall through to `ensureHooksInstalled()` makes the retiring copy race the newer copy's install while writing the *older* hooks.
- **The retiring copy deletes its own bundle** rather than leaving it to the newer copy's cleanup, which calls `removeItem` straight after an asynchronous `forceTerminate()`. On one run that race left the old bundle behind past 20s. Unlinking a running bundle is fine; the process continues until it terminates.

Guards, so this can't misfire: strictly newer only (an equal-version sibling is not superseded), `/Applications` only (a still-mounted DMG stays registered with LaunchServices, and a dev build in a project folder shouldn't be a target either), and it acts only once the copy it asked for is confirmed up, so a failed launch leaves us running, so the worst case degrades to today's behaviour rather than no icon.

## Issue

#45

## How you tested it

Built off latest `main` (`e9aab3e`). macOS 26.5.2, Apple Silicon, Xcode 26.5 SDK, Swift 6.3.3. Zero compiler warnings.

The bug itself was not staged. I found it live on my own machine, four days into thinking I was running 0.4.1 while a hook-launched 0.3.4 owned the menu bar and had reverted my hooks. Details in the issue.

To test the fix I staged the same collision deliberately: a patched build at `/Applications/ClaudeStatusBar.app`, a patched build bumped to 0.4.2 at `/Applications/Claude Status Bar.app`, `installedVersion` reset, and the 0.3.4-era hooks put back in `~/.claude/statusbar/` each run.

**Handoff, launched both ways** (directly by path, and through the hooks' own `open -g -b`):

```
t+1   ClaudeStatusBar,                     stale:present
t+2   Claude Status Bar,                   stale:DELETED
>>> converged at t+2s
```

7 runs, converged at 2s, 2s, 2s, 9s, 3s, 3s, 3s (the last two with a live CLI session present). Every run ended with exactly one bundle in `/Applications`, one running instance, and no leftover.

**Hook clobber (the race in the second bullet above).** Ran with genuinely different hooks in each bundle (0.3.4's real `update.js`/`lifecycle.js` inside the stale bundle, current ones in the newer bundle), so a clobber would be visible as a hash:

```
stale bundle's hooks : 75d55e02dad843e4  (0.3.4)
new bundle's hooks   : ebd8984821024564  (current)
after handoff:
  bundles left     : Claude Status Bar.app
  INSTALLED hooks  : ebd8984821024564   <- current, correct
  installedVersion : 0.4.2              <- set by the newer copy, not the retiring one
```

4/4 runs. Worth noting for anyone testing this: `ensureHooksInstalled()` runs async, so checking the hook hash within ~3s of the handoff still shows the old one. It settles a few seconds later. Before the `init()` return was added this reported `installedVersion: 0.4.1`, i.e. the retiring copy had written its own hooks on the way out.

**Guard cases:**

- Old-named copy alone, no newer copy installed (the dev-build case the original comment calls out): no handoff, keeps running, bundle intact.
- Two copies at the *same* version: no handoff, one instance, old bundle untouched, so no launch loop.
- Copy-selection logic exercised against the live LaunchServices list: both `/Volumes` installer copies and the project-folder dev build correctly excluded, `/Applications` copy selected; `max` returns the highest version (`0.10.0` over `0.4.10`, so the numeric compare holds).

- [x] Tested in the **Claude desktop app**: this is where I hit the bug and where I verified the fix. The app tracked live desktop sessions throughout (state transitions, timer, session rows) with the patched build.
- [x] Tested in the **CLI, in a terminal**: the handoff runs above were done with a live Claude Code CLI session running the whole time, alongside two desktop sessions. After each handoff the surviving copy still tracked all three, CLI session included, with the correct `CLI` surface and terminal recorded in its state file.
- **Which terminal did you use?** Terminal.app (the live CLI session reported `term_program=Apple_Terminal`). I could not get a session going in Ghostty for this round, so I have not verified Ghostty specifically, so happy to redo it there if you want that covered, since I know behaviour differs between terminals.

No screenshot attached: nothing here changes what's drawn. The observable behaviour is which bundle owns the menu bar, so the terminal output above is the evidence. Happy to record something if you'd rather see it.

## Checklist
- [x] I built off the latest `main`, so I'm not fixing something that already changed.
- [x] One focused change, not a bundle of unrelated edits.
- [ ] Screenshot or short screen recording attached for any visual or timing change. n/a, no visual change; terminal evidence above
- [x] I read CONTRIBUTING.md and the known issues (#22), and this fits the scope.

## Is this for everyone, or is it your fork?

For everyone on the upgrade path. It only triggers when a pre-0.4.0 bundle is still sitting in `/Applications` next to a newer one, and it's inert on a clean install. No new settings, no dependencies, no behaviour change for anyone already running a single copy.
