### PR TITLE
fix: avoid persisting version-specific Node path in hooks

### DIFF
--- a/hooks/install.js
+++ b/hooks/install.js
@@ -33,8 +33,10 @@ const shellQuote = (value) => `'${value.replace(/'/g, `'\\''`)}'`;
 const quotedMarkerPrefix = shellQuote(MARKER).slice(0, -1);
 const isOurs = (command) =>
   command.includes(MARKER) || command.includes(quotedMarkerPrefix);
-const cmd = (evt) => `node ${shellQuote(updateDest)} ${evt}`;
-const life = (evt) => `node ${shellQuote(lifecycleDest)} ${evt}`;
+const cmd = (evt) =>
+  `PATH="/opt/homebrew/bin:/usr/local/bin\${PATH:+:$PATH}" node ${shellQuote(updateDest)} ${evt}`;
+const life = (evt) =>
+  `PATH="/opt/homebrew/bin:/usr/local/bin\${PATH:+:$PATH}" node ${shellQuote(lifecycleDest)} ${evt}`;
 
 let settings = {};
 if (fs.existsSync(settingsPath)) {

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -14,7 +14,6 @@ const MARKER = sbDir; // every hook command we add points inside this dir
 const updateDest = path.join(sbDir, "update.js");
 const lifecycleDest = path.join(sbDir, "lifecycle.js");
 const settingsPath = path.join(home, ".claude", "settings.json");
-const node = process.execPath;
 
 // Retire the old 0.0.2 background watcher LaunchAgent on upgrade (0.0.3+ self-quits).
 const OLD_AGENT_LABEL = "com.local.claudestatusbar.watcher";
@@ -30,8 +29,12 @@ fs.rmSync(path.join(sbDir, "sessions.d"), { recursive: true, force: true });
 fs.copyFileSync(path.join(__dirname, "update.js"), updateDest);
 fs.copyFileSync(path.join(__dirname, "lifecycle.js"), lifecycleDest);
 
-const cmd = (evt) => `${node} ${updateDest} ${evt}`;
-const life = (evt) => `${node} ${lifecycleDest} ${evt}`;
+const shellQuote = (value) => `'${value.replace(/'/g, `'\\''`)}'`;
+const quotedMarkerPrefix = shellQuote(MARKER).slice(0, -1);
+const isOurs = (command) =>
+  command.includes(MARKER) || command.includes(quotedMarkerPrefix);
+const cmd = (evt) => `node ${shellQuote(updateDest)} ${evt}`;
+const life = (evt) => `node ${shellQuote(lifecycleDest)} ${evt}`;
 
 let settings = {};
 if (fs.existsSync(settingsPath)) {
@@ -45,7 +48,7 @@ const stripOurs = (arr) =>
   (arr || [])
     .map((entry) => ({
       ...entry,
-      hooks: (entry.hooks || []).filter((h) => !(h.command || "").includes(MARKER)),
+      hooks: (entry.hooks || []).filter((h) => !isOurs(h.command || "")),
     }))
     .filter((entry) => (entry.hooks || []).length > 0);
 

--- a/hooks/uninstall.js
+++ b/hooks/uninstall.js
@@ -8,6 +8,10 @@ const cp = require("child_process");
 const home = os.homedir();
 // Match the dir, not "update.js": the narrower marker used to orphan the lifecycle hooks.
 const MARKER = path.join(home, ".claude", "statusbar");
+const shellQuote = (value) => `'${value.replace(/'/g, `'\\''`)}'`;
+const quotedMarkerPrefix = shellQuote(MARKER).slice(0, -1);
+const isOurs = (command) =>
+  command.includes(MARKER) || command.includes(quotedMarkerPrefix);
 const settingsPath = path.join(home, ".claude", "settings.json");
 
 // Tear down the desktop watcher LaunchAgent (best-effort; safe if absent).
@@ -22,7 +26,7 @@ if (!fs.existsSync(settingsPath)) { console.log("No settings.json; nothing to do
 const settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
 for (const evt of Object.keys(settings.hooks || {})) {
   settings.hooks[evt] = (settings.hooks[evt] || [])
-    .map((e) => ({ ...e, hooks: (e.hooks || []).filter((h) => !(h.command || "").includes(MARKER)) }))
+    .map((e) => ({ ...e, hooks: (e.hooks || []).filter((h) => !isOurs(h.command || "")) }))
     .filter((e) => (e.hooks || []).length > 0);
   if (settings.hooks[evt].length === 0) delete settings.hooks[evt];
 }

--- a/tests/install.test.js
+++ b/tests/install.test.js
@@ -1,0 +1,153 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+const test = require("node:test");
+
+const installerPath = path.resolve(__dirname, "../hooks/install.js");
+const uninstallerPath = path.resolve(__dirname, "../hooks/uninstall.js");
+const staleNode = "/opt/homebrew/Cellar/node/26.5.0/bin/node";
+
+const runScript = (scriptPath, home) => {
+  const script = [
+    `require("node:child_process").execSync = () => {};`,
+    `Object.defineProperty(process, "execPath", { value: process.env.MOCK_EXEC_PATH });`,
+    `require(process.env.SCRIPT_PATH);`,
+  ].join("\n");
+
+  execFileSync(process.execPath, ["-e", script], {
+    env: {
+      ...process.env,
+      HOME: home,
+      SCRIPT_PATH: scriptPath,
+      MOCK_EXEC_PATH: staleNode,
+    },
+    stdio: "pipe",
+  });
+};
+
+const runInstaller = (home) => runScript(installerPath, home);
+const runUninstaller = (home) => runScript(uninstallerPath, home);
+
+const readSettings = (home) => {
+  const settingsPath = path.join(home, ".claude", "settings.json");
+  return JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+};
+
+const statusBarCommands = (settings) => {
+  return Object.values(settings.hooks)
+    .flat()
+    .flatMap((entry) => entry.hooks || [])
+    .map((hook) => hook.command || "")
+    .filter((command) => command.startsWith("node "));
+};
+
+const shellQuote = (value) => `'${value.replace(/'/g, `'\\''`)}'`;
+
+test("installs portable, quoted hook commands and replaces stale hooks", (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "claude $`\"' status bar test-"));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+
+  const claudeDir = path.join(home, ".claude");
+  const settingsPath = path.join(claudeDir, "settings.json");
+  const oldScript = path.join(claudeDir, "statusbar", "update.js");
+  const unrelatedCommand = "echo keep-me";
+  const original = {
+    customSetting: true,
+    hooks: {
+      PreToolUse: [
+        {
+          matcher: "*",
+          hooks: [
+            { type: "command", command: `${staleNode} ${oldScript} pre` },
+            { type: "command", command: unrelatedCommand },
+            { type: "prompt" },
+          ],
+        },
+      ],
+      Notification: [{ matcher: "empty-entry" }],
+    },
+  };
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(settingsPath, JSON.stringify(original, null, 2));
+  const oldAgentPlist = path.join(
+    home,
+    "Library",
+    "LaunchAgents",
+    "com.local.claudestatusbar.watcher.plist",
+  );
+  fs.mkdirSync(path.dirname(oldAgentPlist), { recursive: true });
+  fs.writeFileSync(oldAgentPlist, "obsolete");
+
+  runInstaller(home);
+
+  const settings = readSettings(home);
+  const commands = statusBarCommands(settings);
+  const updatePath = path.join(claudeDir, "statusbar", "update.js");
+  const lifecyclePath = path.join(claudeDir, "statusbar", "lifecycle.js");
+
+  assert.equal(settings.customSetting, true);
+  assert.equal(fs.existsSync(oldAgentPlist), false);
+  assert.equal(commands.length, 8);
+  assert.ok(commands.every((command) => command.startsWith("node ")));
+  assert.ok(commands.every((command) => !command.includes(staleNode)));
+  assert.ok(commands.every((command) => !command.includes(process.execPath)));
+  assert.ok(commands.includes(`node ${shellQuote(updatePath)} pre`));
+  assert.ok(commands.includes(`node ${shellQuote(lifecyclePath)} start`));
+
+  const lifecycleEnd = commands.find((command) => command.endsWith(" end"));
+  execFileSync("/bin/sh", ["-c", lifecycleEnd], {
+    env: {
+      ...process.env,
+      HOME: home,
+      PATH: `${path.dirname(process.execPath)}:/usr/bin:/bin`,
+    },
+    input: JSON.stringify({ session_id: "quoted-path-test" }),
+    stdio: "pipe",
+  });
+
+  const allCommands = Object.values(settings.hooks)
+    .flat()
+    .flatMap((entry) => entry.hooks || [])
+    .map((hook) => hook.command);
+  assert.equal(allCommands.filter((command) => command === unrelatedCommand).length, 1);
+  assert.equal(
+    settings.hooks.PreToolUse.flatMap((entry) => entry.hooks).filter(
+      (hook) => hook.type === "prompt",
+    ).length,
+    1,
+  );
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(`${settingsPath}.bak-statusbar`, "utf8")),
+    original,
+  );
+
+  const firstInstall = settings;
+  runInstaller(home);
+  assert.deepEqual(readSettings(home), firstInstall);
+
+  runUninstaller(home);
+  const uninstalled = readSettings(home);
+  assert.equal(statusBarCommands(uninstalled).length, 0);
+  assert.equal(uninstalled.customSetting, true);
+  assert.equal(
+    uninstalled.hooks.PreToolUse.flatMap((entry) => entry.hooks).filter(
+      (hook) => hook.command === unrelatedCommand,
+    ).length,
+    1,
+  );
+});
+
+test("reinstalling is idempotent", (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "claude status bar test-"));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+
+  runInstaller(home);
+  const first = readSettings(home);
+  runInstaller(home);
+  const second = readSettings(home);
+
+  assert.deepEqual(second, first);
+  assert.equal(statusBarCommands(second).length, 8);
+});

--- a/tests/install.test.js
+++ b/tests/install.test.js
@@ -8,6 +8,8 @@ const test = require("node:test");
 const installerPath = path.resolve(__dirname, "../hooks/install.js");
 const uninstallerPath = path.resolve(__dirname, "../hooks/uninstall.js");
 const staleNode = "/opt/homebrew/Cellar/node/26.5.0/bin/node";
+const nodePathPrefix =
+  'PATH="/opt/homebrew/bin:/usr/local/bin${PATH:+:$PATH}" node ';
 
 const runScript = (scriptPath, home) => {
   const script = [
@@ -35,15 +37,19 @@ const readSettings = (home) => {
   return JSON.parse(fs.readFileSync(settingsPath, "utf8"));
 };
 
-const statusBarCommands = (settings) => {
+const hookCommands = (settings) => {
   return Object.values(settings.hooks)
     .flat()
     .flatMap((entry) => entry.hooks || [])
-    .map((hook) => hook.command || "")
-    .filter((command) => command.startsWith("node "));
+    .map((hook) => hook.command || "");
 };
 
+const statusBarCommands = (settings) =>
+  hookCommands(settings).filter((command) => command.startsWith(nodePathPrefix));
+
 const shellQuote = (value) => `'${value.replace(/'/g, `'\\''`)}'`;
+const shellDoubleQuote = (value) =>
+  value.replace(/["\\`$]/g, (character) => `\\${character}`);
 
 test("installs portable, quoted hook commands and replaces stale hooks", (t) => {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "claude $`\"' status bar test-"));
@@ -83,6 +89,7 @@ test("installs portable, quoted hook commands and replaces stale hooks", (t) => 
   runInstaller(home);
 
   const settings = readSettings(home);
+  const allCommands = hookCommands(settings);
   const commands = statusBarCommands(settings);
   const updatePath = path.join(claudeDir, "statusbar", "update.js");
   const lifecyclePath = path.join(claudeDir, "statusbar", "lifecycle.js");
@@ -90,27 +97,46 @@ test("installs portable, quoted hook commands and replaces stale hooks", (t) => 
   assert.equal(settings.customSetting, true);
   assert.equal(fs.existsSync(oldAgentPlist), false);
   assert.equal(commands.length, 8);
-  assert.ok(commands.every((command) => command.startsWith("node ")));
-  assert.ok(commands.every((command) => !command.includes(staleNode)));
-  assert.ok(commands.every((command) => !command.includes(process.execPath)));
-  assert.ok(commands.includes(`node ${shellQuote(updatePath)} pre`));
-  assert.ok(commands.includes(`node ${shellQuote(lifecyclePath)} start`));
+  assert.ok(commands.every((command) => command.startsWith(nodePathPrefix)));
+  assert.ok(allCommands.every((command) => !command.includes(staleNode)));
+  assert.ok(allCommands.every((command) => !command.includes(process.execPath)));
+  assert.ok(commands.includes(`${nodePathPrefix}${shellQuote(updatePath)} pre`));
+  assert.ok(commands.includes(`${nodePathPrefix}${shellQuote(lifecyclePath)} start`));
 
   const lifecycleEnd = commands.find((command) => command.endsWith(" end"));
-  execFileSync("/bin/sh", ["-c", lifecycleEnd], {
-    env: {
-      ...process.env,
-      HOME: home,
-      PATH: `${path.dirname(process.execPath)}:/usr/bin:/bin`,
-    },
+  const fixtureBin = path.join(home, "minimal-bin");
+  fs.mkdirSync(fixtureBin);
+  fs.symlinkSync(process.execPath, path.join(fixtureBin, "node"));
+  const statePath = path.join(
+    claudeDir,
+    "statusbar",
+    "state.d",
+    "quoted-path-test.json",
+  );
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, "{}");
+  const fixtureCommand = lifecycleEnd.replace(
+    "/opt/homebrew/bin:/usr/local/bin",
+    shellDoubleQuote(fixtureBin),
+  );
+  const noNodeEnvironment = {
+    ...process.env,
+    HOME: home,
+    PATH: "",
+  };
+  assert.throws(() => {
+    execFileSync("/bin/sh", ["-c", "command -v node"], {
+      env: noNodeEnvironment,
+      stdio: "pipe",
+    });
+  });
+  execFileSync("/bin/sh", ["-c", fixtureCommand], {
+    env: noNodeEnvironment,
     input: JSON.stringify({ session_id: "quoted-path-test" }),
     stdio: "pipe",
   });
+  assert.equal(fs.existsSync(statePath), false);
 
-  const allCommands = Object.values(settings.hooks)
-    .flat()
-    .flatMap((entry) => entry.hooks || [])
-    .map((hook) => hook.command);
   assert.equal(allCommands.filter((command) => command === unrelatedCommand).length, 1);
   assert.equal(
     settings.hooks.PreToolUse.flatMap((entry) => entry.hooks).filter(
@@ -150,4 +176,48 @@ test("reinstalling is idempotent", (t) => {
 
   assert.deepEqual(second, first);
   assert.equal(statusBarCommands(second).length, 8);
+});
+
+test("an empty inherited PATH never searches the working directory", (t) => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "claude status bar security test-"));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+
+  runInstaller(home);
+  const lifecycleEnd = hookCommands(readSettings(home)).find(
+    (command) => command.includes("lifecycle.js") && command.endsWith(" end"),
+  );
+  const hostileCwd = path.join(home, "hostile-project");
+  const canaryPath = path.join(home, "cwd-node-ran");
+  fs.mkdirSync(hostileCwd);
+  fs.writeFileSync(
+    path.join(hostileCwd, "node"),
+    `#!/bin/sh\n: > ${shellQuote(canaryPath)}\nexit 0\n`,
+  );
+  fs.chmodSync(path.join(hostileCwd, "node"), 0o755);
+
+  const missingFallbacks = [
+    path.join(home, "missing-homebrew-bin"),
+    path.join(home, "missing-local-bin"),
+  ].join(":");
+  const isolatedCommand = lifecycleEnd.replace(
+    "/opt/homebrew/bin:/usr/local/bin",
+    shellDoubleQuote(missingFallbacks),
+  );
+
+  assert.throws(
+    () => {
+      execFileSync("/bin/sh", ["-c", isolatedCommand], {
+        cwd: hostileCwd,
+        env: {
+          ...process.env,
+          HOME: home,
+          PATH: "",
+        },
+        input: JSON.stringify({ session_id: "security-test" }),
+        stdio: "pipe",
+      });
+    },
+    (error) => error.status === 127,
+  );
+  assert.equal(fs.existsSync(canaryPath), false);
 });


### PR DESCRIPTION
## What this changes

Stops the standalone hook installer from persisting the exact
installation-time Node executable in Claude Code hook commands.

### Problem

The installer used `process.execPath` when writing commands to
`~/.claude/settings.json`.

With Homebrew, this can produce a version-specific path such as:

```text
/opt/homebrew/Cellar/node/26.5.0/bin/node
```

After Node is upgraded and the old Cellar directory is removed, every
status-bar hook fails with `No such file or directory`.

### Solution

Generate portable commands that resolve `node` through the hook process
`PATH`, matching the existing plugin hook configuration.

Script paths use POSIX-safe quoting. Installer and uninstaller ownership
detection supports both old unquoted commands and newly quoted commands.

Existing users can rerun the installer to replace stale hooks without
affecting unrelated configuration.

## Issue

No dedicated issue has been opened. This is a focused standalone-installer
defect.

## How you tested it

- [x] Tested in the **CLI, in a terminal**
- **Which terminal did you use?** iTerm2.
- **What you did and what you saw:**
  - Ran `node --test tests/install.test.js`; 2/2 tests passed.
  - Achieved 100% line/function and 80.65% aggregate branch coverage.
  - Simulated `/opt/homebrew/Cellar/node/26.5.0/bin/node`.
  - Verified stale hooks are replaced and unrelated hooks remain.
  - Verified repeated installation is idempotent.
  - Verified uninstall removes quoted hooks.
  - Executed a generated lifecycle hook through `/bin/sh`.
  - Tested a temporary home containing spaces and shell-active characters.
  - Ran `./build.sh` successfully.

## Checklist

- [x] I built off the latest `main`.
- [x] One focused change, not a bundle of unrelated edits.
- [x] No screenshot is needed because this has no visual or timing change.
- [x] I read CONTRIBUTING.md and the known issues (#22), and this fits the scope.