### PR TITLE
feat: honor ignoreSurfaces in uiconfig.json to skip Cursor sessions

### DIFF
--- a/hooks/lifecycle.js
+++ b/hooks/lifecycle.js
@@ -17,6 +17,21 @@ fs.mkdirSync(stateDir, { recursive: true });
 const running = () => { try { cp.execSync(`pgrep -x ${EXEC}`, { stdio: "ignore" }); return true; } catch { return false; } };
 const safeId = (s) => String(s || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64) || "unknown";
 
+// Optional per-machine tuning file for the app's dropdown; absent by default, installs never
+// touch it. ignoreSurfaces: ["cursor"] skips sessions whose transcript_path is under ~/.cursor/
+// (Cursor's Claude Code extension). Missing file, missing key, or malformed JSON == track everything.
+const uiConfigPath = path.join(dir, "uiconfig.json");
+const cursorDir = path.join(os.homedir(), ".cursor") + path.sep;
+const isIgnoredCursorSession = (transcriptPath) => {
+  if (typeof transcriptPath !== "string" || !transcriptPath.startsWith(cursorDir)) return false;
+  try {
+    const cfg = JSON.parse(fs.readFileSync(uiConfigPath, "utf8"));
+    return Array.isArray(cfg.ignoreSurfaces) && cfg.ignoreSurfaces.includes("cursor");
+  } catch {
+    return false;
+  }
+};
+
 const writeAtomic = (file, obj) => {
   const tmp = file + "." + process.pid + ".tmp";
   fs.writeFileSync(tmp, JSON.stringify(obj));
@@ -31,8 +46,9 @@ setTimeout(run, 1000); // hooks always pipe stdin, but never hang the session
 
 function run() {
   if (done) return; done = true;
-  let id = "", cwd = "";
-  try { const j = JSON.parse(input); id = j.session_id; cwd = j.cwd || ""; } catch {}
+  let id = "", cwd = "", transcript = "";
+  try { const j = JSON.parse(input); id = j.session_id; cwd = j.cwd || ""; transcript = j.transcript_path || ""; } catch {}
+  if (isIgnoredCursorSession(transcript)) { process.exit(0); }
   id = safeId(id);
   const statePath = path.join(stateDir, id + ".json");
 

--- a/hooks/update.js
+++ b/hooks/update.js
@@ -23,11 +23,28 @@ const TOOL_LABELS = {
 
 const safeId = (s) => String(s || "").replace(/[^A-Za-z0-9_.-]/g, "").slice(0, 64) || "unknown";
 
+// Optional per-machine tuning file for the app's dropdown; absent by default, installs never
+// touch it. ignoreSurfaces: ["cursor"] skips sessions whose transcript_path is under ~/.cursor/
+// (Cursor's Claude Code extension). Missing file, missing key, or malformed JSON == track everything.
+const uiConfigPath = path.join(dir, "uiconfig.json");
+const cursorDir = path.join(os.homedir(), ".cursor") + path.sep;
+const isIgnoredCursorSession = (transcriptPath) => {
+  if (typeof transcriptPath !== "string" || !transcriptPath.startsWith(cursorDir)) return false;
+  try {
+    const cfg = JSON.parse(fs.readFileSync(uiConfigPath, "utf8"));
+    return Array.isArray(cfg.ignoreSurfaces) && cfg.ignoreSurfaces.includes("cursor");
+  } catch {
+    return false;
+  }
+};
+
 let raw = "";
 process.stdin.on("data", (d) => (raw += d));
 process.stdin.on("end", () => {
   let p = {};
   try { p = JSON.parse(raw || "{}"); } catch {}
+
+  if (isIgnoredCursorSession(p.transcript_path)) return;
 
   // Off by default; CLAUDE_STATUSBAR_DEBUG=1 logs every hook invocation to hooks.log.
   if (process.env.CLAUDE_STATUSBAR_DEBUG === "1") {


### PR DESCRIPTION
Closes #49.

`update.js` and `lifecycle.js` now read the optional `~/.claude/statusbar/uiconfig.json`
and skip a session when `ignoreSurfaces` includes `"cursor"` and the session's
`transcript_path` starts with `~/.cursor/`. Missing file, missing key, or malformed
JSON keeps today's behavior (track everything). No app changes, no new files.

The guard checks the transcript-path prefix before touching uiconfig.json, so
CLI/desktop sessions (the common case) do zero extra file I/O.

## Testing

- **CLI**: tracked with the key off; still tracked with the key on (non-Cursor,
  unaffected). Terminal: Ghostty.
- **Claude Desktop**: same — tracked with the key on, confirmed against a real
  in-progress agent session (`ts` kept advancing in its state file).
- **Cursor**: live-tested both ways.
  - Key on: sent a prompt in Cursor's Claude Code extension — no state file was
    written, no relaunch.
  - Key off (control): same prompt — a state file *was* written, with
    `transcript_path` under `~/.cursor/projects/.../agent-transcripts/...`,
    confirming both that the hook pipeline is real and that the path pattern
    matches what the guard checks.
- **Malformed/missing uiconfig.json**: verified in isolated tests (`HOME`
  redirected to a scratch dir) — absent file, absent key, and invalid JSON all
  fall back to tracking everything, for both scripts and all hook events
  (`prompt`, `pre`, `post`, `start`, `end`).
- **Upgrade persistence**: installed an older release (v0.4.0, forced via a
  reset `installedVersion` default so `install.js` actually re-ran), confirmed
  `uiconfig.json` survived untouched while the hooks were overwritten with the
  release's originals (expected — that's what `install.js` does). Then upgraded
  to v0.4.1 via `brew reinstall --cask claude-status-bar`; `uiconfig.json`
  survived that too.

## One thing I noticed, not fixed here

A `Task`-delegated subagent spawned during a Cursor session got its own hook
events with an **empty** `transcript_path`/`cwd` (different `session_id` than
the parent session). Since the guard only matches on `transcript_path`, an
event like that wouldn't be caught even with the key on — it slipped through
in one of my live tests. This matches the detection method as specified
(`transcript_path` under `~/.cursor/`), so I didn't try to paper over it with
a heuristic, but flagging it in case it's worth a follow-up.