### PR TITLE
perf: cut idle and animating CPU (#53)

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -371,6 +371,8 @@ final class StatusController: NSObject, NSMenuDelegate {
     // Tinted frames are deterministic per (style, frame, color); rebuilding one per animation
     // step re-rasterized identical images at fps. Cleared when the style or color changes.
     var iconCache: [String: NSImage] = [:]
+    var turnLineCache: [String: (mtime: Date?, line: String?)] = [:]
+    var desktopRunning = false
 
     let brand = NSColor(srgbRed: 0.851, green: 0.467, blue: 0.341, alpha: 1) // #d97757, Anthropic's official "Orange" accent
     let amber = NSColor(srgbRed: 0.95, green: 0.73, blue: 0.18, alpha: 1) // "awaiting permission" yellow dot
@@ -461,6 +463,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         RunLoop.main.add(t, forMode: .common)
         pollTimer = t
         tick()
+        observeDesktopApp()
         try? FileManager.default.removeItem(atPath: (NSHomeDirectory() as NSString).appendingPathComponent(".claude/statusbar/quit-intent"))
         removeOldNamedBundle()
         ensureHooksInstalled()
@@ -668,7 +671,7 @@ final class StatusController: NSObject, NSMenuDelegate {
                 sessionMenuItems.append((it, s.id))  // kept so tick() can live-update the timers
             }
             menu.addItem(.separator())
-        } else if claudeDesktopRunning() {
+        } else if desktopRunning {
             // No live session to pin, but the desktop app is up — give a way to jump back in.
             menu.addItem(header("Sessions"))
             let open = NSMenuItem(title: "Open Claude", action: #selector(openClaude), keyEquivalent: "")
@@ -1210,11 +1213,22 @@ final class StatusController: NSObject, NSMenuDelegate {
     // Per-session effective state with two recovery nets: an absolute age cap, plus the transcript
     // "interrupted by user" marker (Esc / denied permission fire no hook, freezing the file). "done"
     // collapses to rest.
+    // effectiveState runs every tick for every working session; re-tailing the transcript each
+    // time was 8KB of file I/O per session at 2.5 Hz. Transcripts only grow when text streams
+    // (~20s apart), so gate the read on mtime.
+    func cachedLastTurnLine(_ path: String) -> String? {
+        let m = (try? FileManager.default.attributesOfItem(atPath: path))?[.modificationDate] as? Date
+        if let hit = turnLineCache[path], hit.mtime == m { return hit.line }
+        let line = lastTurnLine(ofFileAt: path)
+        turnLineCache[path] = (m, line)
+        return line
+    }
+
     func effectiveState(_ s: Session, now: Double) -> String {
         if s.state == "thinking" || s.state == "tool" || s.state == "permission" {
             let cap: Double = s.state == "permission" ? 7200 : 900
             if now - s.ts > cap { return "idle" }
-            if !s.transcript.isEmpty, let last = lastTurnLine(ofFileAt: s.transcript),
+            if !s.transcript.isEmpty, let last = cachedLastTurnLine(s.transcript),
                last.contains("interrupted by user") { return "idle" }
             return s.state
         }
@@ -1224,10 +1238,25 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     // MARK: self-quit lifecycle
 
-    // Targeted LaunchServices query: enumerating runningApplications and reading .bundleIdentifier
-    // on each forces a synchronous XPC fetch for any app whose static info isn't cached yet.
-    func claudeDesktopRunning() -> Bool {
+    // Asking LaunchServices on every tick meant a synchronous XPC round-trip at 2.5 Hz. Workspace
+    // notifications keep a flag instead; the authoritative query runs only at the quit decision,
+    // so a missed notification can delay a quit by one debounce but can never quit under a live app.
+    func claudeDesktopRunningLive() -> Bool {
         !NSRunningApplication.runningApplications(withBundleIdentifier: claudeDesktopBundleID).isEmpty
+    }
+
+    func observeDesktopApp() {
+        desktopRunning = claudeDesktopRunningLive()
+        let nc = NSWorkspace.shared.notificationCenter
+        for (name, running) in [(NSWorkspace.didLaunchApplicationNotification, true),
+                                (NSWorkspace.didTerminateApplicationNotification, false)] {
+            nc.addObserver(forName: name, object: nil, queue: .main) { [weak self] note in
+                guard let self,
+                      let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+                      app.bundleIdentifier == self.claudeDesktopBundleID else { return }
+                self.desktopRunning = running
+            }
+        }
     }
 
     func sessionCount() -> Int { stateFileNames().count }
@@ -1244,12 +1273,15 @@ final class StatusController: NSObject, NSMenuDelegate {
     func checkLifecycle() {
         let now = Date()
         if now.timeIntervalSince(launchedAt) < launchGrace { return }
-        if claudeDesktopRunning() || sessionCount() > 0 {
+        if desktopRunning || sessionCount() > 0 {
             notNeededSince = nil
             return
         }
         if let since = notNeededSince {
-            if now.timeIntervalSince(since) >= idleQuitDelay { NSApp.terminate(nil) }
+            if now.timeIntervalSince(since) >= idleQuitDelay {
+                if claudeDesktopRunningLive() { desktopRunning = true; notNeededSince = nil; return }
+                NSApp.terminate(nil)
+            }
         } else {
             notNeededSince = now
         }

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -367,6 +367,10 @@ final class StatusController: NSObject, NSMenuDelegate {
     var activeBase = ""        // label without the elapsed clock
     var startedAt: Double = 0  // unix seconds the current turn began (0 = no clock)
     var activeColor: NSColor? = nil
+    var lastTitleText: String? = nil
+    // Tinted frames are deterministic per (style, frame, color); rebuilding one per animation
+    // step re-rasterized identical images at fps. Cleared when the style or color changes.
+    var iconCache: [String: NSImage] = [:]
 
     let brand = NSColor(srgbRed: 0.851, green: 0.467, blue: 0.341, alpha: 1) // #d97757, Anthropic's official "Orange" accent
     let amber = NSColor(srgbRed: 0.95, green: 0.73, blue: 0.18, alpha: 1) // "awaiting permission" yellow dot
@@ -1012,6 +1016,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         guard let sys = sender.representedObject as? Bool else { return }
         iconSystem = sys
         UserDefaults.standard.set(iconSystem, forKey: "iconSystem")
+        iconCache.removeAll()
         evaluate() // re-render the current state in the new color
     }
 
@@ -1025,6 +1030,7 @@ final class StatusController: NSObject, NSMenuDelegate {
         guard let raw = sender.representedObject as? String, let st = AnimStyle(rawValue: raw) else { return }
         animStyle = st
         UserDefaults.standard.set(raw, forKey: "animStyle")
+        iconCache.removeAll()
         animTimer?.invalidate(); animTimer = nil // recreate at the new style's fps
         frameIdx = 0
         evaluate()
@@ -1218,8 +1224,10 @@ final class StatusController: NSObject, NSMenuDelegate {
 
     // MARK: self-quit lifecycle
 
+    // Targeted LaunchServices query: enumerating runningApplications and reading .bundleIdentifier
+    // on each forces a synchronous XPC fetch for any app whose static info isn't cached yet.
     func claudeDesktopRunning() -> Bool {
-        NSWorkspace.shared.runningApplications.contains { $0.bundleIdentifier == claudeDesktopBundleID }
+        !NSRunningApplication.runningApplications(withBundleIdentifier: claudeDesktopBundleID).isEmpty
     }
 
     func sessionCount() -> Int { stateFileNames().count }
@@ -1309,6 +1317,12 @@ final class StatusController: NSObject, NSMenuDelegate {
         if showTimer, startedAt > 0 {
             text += "  " + elapsed(max(0, Int(Date().timeIntervalSince1970 - startedAt)))
         }
+        // Assigning attributedTitle re-shapes the string through CoreText and re-snapshots the
+        // status item bitmap, so at animation fps an unchanged title costs a full redraw per frame
+        // (the clock only ticks at 1 Hz). labelColor is dynamic and resolves at draw, so skipping
+        // the assignment still tracks light/dark menu bars.
+        guard text != lastTitleText else { return }
+        lastTitleText = text
         if text.isEmpty {
             button.imagePosition = .imageOnly
             button.attributedTitle = NSAttributedString(string: "")
@@ -1332,6 +1346,14 @@ final class StatusController: NSObject, NSMenuDelegate {
     }
 
     func iconImage(color: NSColor?, frame: Int) -> NSImage {
+        let key = "\(animStyle.rawValue)|\(frame)|\(color == nil ? "template" : color!.description)"
+        if let cached = iconCache[key] { return cached }
+        let img = buildIconImage(color: color, frame: frame)
+        iconCache[key] = img
+        return img
+    }
+
+    func buildIconImage(color: NSColor?, frame: Int) -> NSImage {
         if animStyle == .web { return tint(frames, color: color, frame: frame) }
         if animStyle == .crab { return crabIcon(color: color, frame: frame) }
         let i = (frame / codeSub) % codeGlyphs.count


### PR DESCRIPTION
Addresses #53. @Bardin08's three diagnoses all checked out against the source. This implements them, plus one more cause he didn't have visibility into.

## Changes

**1. `applyTitle()` skips redundant assignments.** It rebuilt and reassigned `button.attributedTitle` on every animation frame, so at 9–12.5 fps AppKit re-shaped the string through CoreText and re-snapshotted the status item ~10x/second for a clock that only ticks at 1 Hz. Now it compares the composed text and returns early when nothing changed. Dynamic `labelColor` still tracks light/dark menu bars, since system colors resolve at draw rather than at assignment.

**2. Tinted frames are cached** per (style, frame, color) instead of being re-rasterized every step. Cleared when the style or color setting changes.

**3. The LaunchServices call is out of the tick.** To be clear about scope: the 0.4 s poll itself is unchanged, and the tick still lists `state.d/`, re-parses changed session files and re-renders. What changed is that asking macOS "is the desktop app running?" no longer happens inside it. `NSWorkspace` launch/terminate notifications keep a flag, and the authoritative query runs only at the moment the app would actually quit. So a missed notification can delay a quit by one debounce interval, but can never quit while the desktop app is live.

**4. Transcript tail reads are cached by mtime.** Not in the report: `effectiveState()` runs every tick for every session, and for any session in `thinking`/`tool`/`permission` it called `lastTurnLine()`, which opens the transcript, seeks to the end, reads an 8 KB tail and splits it into lines. That was file I/O on the main thread at 2.5 Hz per working session, and it scaled with session count. Transcripts only grow when text streams (~20 s apart), so the read is now gated on mtime.

Not included: the `DispatchSource` watch for `state.d/` (measured in microseconds here, not worth the moving parts), and pausing the animation when nothing is visible — see the idle number below for why I don't think that one is the lever.

## Benchmark

Method: N synthetic sessions pinned in a fixed state with live pids and real ~200 KB transcript files, nothing else in `state.d/`, timer enabled, measuring accumulated process CPU time over a fixed 25 s window (`ps -o cputime` delta / wall time) rather than instantaneous Activity Monitor samples. Same machine, back to back, M1 Pro on macOS 26. Repeat runs varied by ±0.1.

| scenario | main | this branch |
|---|---|---|
| idle, resting icon | 2.0% | **1.2%** |
| Claude Spark, 9 fps | 5.5% | **3.8%** |
| Crab Walking, 12.5 fps | 6.6% | **4.7%** |
| Claude Code glyphs | 11.3% | **9.1%** |

The idle row is the one I'd point at: with no animation running at all, the drop from 2.0% to 1.2% is almost entirely your #3. My first micro-benchmark of that call showed 0.089 ms vs 0.072 ms and I nearly dismissed it — in the long-running app at 2.5 Hz it turns out to be worth about 0.8% of a core continuously. You were right and my spot check was wrong.

### Scaling with concurrent working sessions

Same method, Claude Spark, runs interleaved between builds to cancel machine drift:

| sessions in a working state | main | this branch |
|---|---|---|
| 1 | 5.9% | 3.9% |
| 10 | 9.1% | 4.8% |
| 20 | 11.7% / 11.4% | 5.3% / 5.7% |

That works out to roughly **+0.3% of a core per working session on main, versus +0.08% on the branch**. At 20 concurrent working sessions it's a straight halving, and the gap keeps widening from there.

(The 1-session Spark figure differs slightly between the two tables, 5.5% vs 5.9%, because the sessions in the first table have no transcript attached and the ones here do. That 0.4% gap is the transcript tail read for a single session.)

This is the transcript-tail fix, and it's the part a single-session profile doesn't surface: every session in `thinking`/`tool`/`permission` re-read the last 8 KB of its own transcript on every 2.5 Hz tick, so the cost was multiplied by how many sessions were live at once, not by anything the animation was doing. If you keep a lot of sessions alive around the clock, this is likely a bigger factor for you than the redraw path.

## What I can't reproduce, and what would help

This machine idles at 1.2% and animates at 3.8%, and it idled at ~1.3% even before the patch. Your 25–27% sustained is roughly 4x anything I can produce here, so something on your setup is materially more expensive than mine — most likely the LaunchServices path, given how much bigger it is in your profile than in my measurements.

If you have the time to build this branch and re-run `sample`:

1. Does `_LSCopyApplicationInformation` disappear from the profile entirely? It should now, since the call is gone from the tick.
2. Does the `_updateReplicantsUnlessMenuIsTracking:` share drop?
3. Where does your sustained % settle over a long window?

If it's still bad on your hardware after this, the next thing I'd chase is the Claude Code glyph style specifically: it costs 2.4x the spark style here even with every frame cached, which doesn't follow from its frame rate alone. My suspicion is the scale envelope changes the rendered image size per frame and forces a status-item relayout on every step. That would be a separate fix.
